### PR TITLE
Change MIME type to be immutable value set in Construct of generic parts

### DIFF
--- a/src/AbstractPart.php
+++ b/src/AbstractPart.php
@@ -36,7 +36,7 @@ abstract class AbstractPart
     /**
      * @var string
      */
-    protected $type     = null;
+    protected $type;
 
     /**
      * @var string

--- a/src/Content/Content.php
+++ b/src/Content/Content.php
@@ -5,19 +5,12 @@ namespace Phlib\Mail\Content;
 class Content extends AbstractContent
 {
     /**
-     * @var string
-     */
-    protected $type = 'application/octet-stream';
-
-    /**
-     * Set type
+     * Constructor to set immutable values
      *
      * @param string $type
-     * @return \Phlib\Mail\Content\Content
      */
-    public function setType($type)
+    public function __construct($type = 'application/octet-stream')
     {
         $this->type = $type;
-        return $this;
     }
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -257,8 +257,7 @@ class Factory
                     }
                     break;
                 default:
-                    $mailPart = new Mime\Mime();
-                    $mailPart->setType($type);
+                    $mailPart = new Mime\Mime($type);
                     break;
             }
 
@@ -277,10 +276,9 @@ class Factory
             if ($name != '1' && $disposition !== false) {
                 // It's an attachment
                 $mail->incrementAttachmentCount();
-                $mailPart = new Content\Content();
-                $mailPart->setEncoding('base64');
                 // Use the original type, as it contains the attachment name
-                $mailPart->setType($partData['headers']['content-type']);
+                $mailPart = new Content\Content($partData['headers']['content-type']);
+                $mailPart->setEncoding('base64');
             } else {
                 // Basic content
                 switch ($type) {
@@ -293,8 +291,7 @@ class Factory
                     default:
                         // It's not HTML or text, so we class it as an attachment
                         $mail->incrementAttachmentCount();
-                        $mailPart = new Content\Content();
-                        $mailPart->setType($type);
+                        $mailPart = new Content\Content($type);
                         $mailPart->setEncoding($partData['transfer-encoding']);
                         break;
                 }

--- a/src/Mime/Mime.php
+++ b/src/Mime/Mime.php
@@ -5,14 +5,12 @@ namespace Phlib\Mail\Mime;
 class Mime extends AbstractMime
 {
     /**
-     * Set type
+     * Constructor to set immutable values
      *
      * @param string $type
-     * @return \Phlib\Mail\Mime\Mime
      */
-    public function setType($type)
+    public function __construct($type)
     {
         $this->type = $type;
-        return $this;
     }
 }

--- a/tests/Content/ContentTest.php
+++ b/tests/Content/ContentTest.php
@@ -6,27 +6,16 @@ use Phlib\Mail\Content\Content;
 
 class ContentTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @var Content
-     */
-    protected $part;
-
-    protected function setUp()
-    {
-        $this->part = new Content();
-    }
-
     public function testGetTypeDefault()
     {
-        $type = "application/octet-stream";
-        $this->assertEquals($type, $this->part->getType());
+        $part = new Content();
+        $this->assertEquals('application/octet-stream', $part->getType());
     }
 
     public function testSetGetType()
     {
-        $type = "text/plain";
-        $this->part->setType($type);
-
-        $this->assertEquals($type, $this->part->getType());
+        $type = 'text/plain';
+        $part = new Content($type);
+        $this->assertEquals($type, $part->getType());
     }
 }

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -59,7 +59,7 @@ class MailTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetEncodedHeadersWithData()
     {
-        $part = new Mime();
+        $part = new Mime('multipart/other');
         $this->mail->setPart($part);
 
         $expected = $this->addHeaders();

--- a/tests/Mime/MimeTest.php
+++ b/tests/Mime/MimeTest.php
@@ -6,21 +6,11 @@ use Phlib\Mail\Mime\Mime;
 
 class MimeTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @var Mime
-     */
-    protected $part;
-
-    protected function setUp()
-    {
-        $this->part = new Mime();
-    }
-
     public function testSetGetType()
     {
-        $type = "multipart/other";
-        $this->part->setType($type);
+        $type = 'multipart/other';
+        $part = new Mime($type);
 
-        $this->assertEquals($type, $this->part->getType());
+        $this->assertEquals($type, $part->getType());
     }
 }


### PR DESCRIPTION
BC break as it introduces parameters to the construct and removes `setType` from `Content/Content` and `Mime/Mime`
