### PR TITLE
Add Factory config option skipErrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- `Factory` can be constructed with a config (also available on `create*()`
+  methods)
+- `Factory` config option *skipErrors*. Default disabled. When enabled the
+  Factory will attempt to continue when encountering parse errors, to produce
+  the best possible representation of the raw message.
 ### Changed
-- Simplified result array for `Factory::decodeHeader()` to just contain the charset of the resulting string
+- Simplified result array for `Factory::decodeHeader()` to just contain the
+  charset of the resulting string
 
 ## [1.0.0] - 2017-02-07
 ### Added

--- a/tests/__files/broken_header-expected-headers.txt
+++ b/tests/__files/broken_header-expected-headers.txt
@@ -1,0 +1,19 @@
+Return-Path: <bounce-100-250-1831-live@mail.example.com>
+From: Events <eventmarketing@example.com>
+To: recipient@example.com
+Reply-To: Events <eventmarketing@example.com>
+Received: from gbnthda3150srv.example.com ([10.67.121.52]) by GBLONVMSX001.nsicorp.int with Microsoft SMTPSVC(6.0.3790.4675);  Thu, 29 Sep 2011 08:48:51 +0100
+Received: from localhost (unknown [127.0.0.1]) by IMSVA80 (Postfix) with SMTP id E307622003E for <recipient@example.com>; Thu, 29 Sep 2011 08:48:58 +0100 (BST)
+Received: from mta6551.example.com (unknown [109.68.65.51]) by gbnthda3150srv.example.com (Postfix) with ESMTP id 6F72A220057 for <recipient@example.com>; Fri, 23 Sep 2011 09:54:25 +0100 (BST)
+Received: by mta6551.example.com (PowerMTA(TM) v3.5r14) id hfh4js0sv5km for <recipient@example.com>; Fri, 23 Sep 2011 09:54:22 +0100 (envelope-from <bounce-100-250-1831-live@mail.example.com>)
+X-Mailer: MXM-v5-MailEngine
+Message-Id: <0.0.24D.2F1.1CC79CE6346CBD8.0@mta6551.example.com>
+Date: Fri, 23 Sep 2011 09:54:22 +0100
+X-Tm-As-Product-Ver: SMEX-8.0.0.1181-6.500.1024-18336.002
+X-Tm-As-Result: No--4.601200-8.000000-31
+X-Imss-Scan-Details: No--12.138-5.0-31-10
+X-Tm-As-User-Approved-Sender: No
+X-Tm-As-Result-Xfilter: Match text exemption rules:No
+X-Tmase-Matchedrid: Q2+zkeG6t3p+YGzLN7T7mqGIP6nmLu6LLw30/c3NkEDNcm2bW2t5nPvA DvTnCf5vDYBVKmbeeQOVIU9/CM32kdWn59xnE0iHoMd8fz60W5eYrH5+aA00En4WoLVkiF5MrDF tme53KvtDGFvBeB2nXEK7eJQWtfQOGbNuSeNqcN92KN90fG2iIujLQmIoVnOSG1CvAg7R8yRFxL gyMr3q0aFI/hOhKe2if7FDYGpyXq3img94X0eg/ol1yzEgrR9NPGMCwqTcrWssXJM82Uy2JgQYC cQrwdJfGSqdEmeD/nVEm2z04jGoEw1UcnuLpxYgVQqcStBKJr9uLA60aUCmmFVBWgEsQzu09Szz aTBwGVB52IkwyV1HePn4mcXPgnU12UI6LaiL1lWZYZEz3zbAyntZCpfMKy9fNLOElW08UrbU3m2 KoscyCyz67EO943zmJKoUzP1GfbbbTWWstzOlSzW9LFay9u07Cbx7yn3FMqIDf5+W2YF4RXYiw8 L1nrYYh+w9Wz/xXDptPXRTHBlYsAIxQkXDtNe7Da6S/pucmjtaiKNTrM3yG19IvYJOgu3ChDqIQ b7sQeeO74ZfTyAQsL6nzxSJcwn0YZPliWGvyajMgKQ8B6MJ9cKjqJxyhMunKMLj+jsQyO/wI5Ez JETTVCI9VGugnfROACF5TKaad195Jkx0cWUhes4ygPHg/CeBfk8FD2cg0j/trubt8TkL4ZQ7SU/ QtiDSa/fioJ9l4HhhV/XBZzYTCF8baTVx8DUoCOVnyuVVgerk/4xeauuY7zo7wMLyyGiGIj0zFI 5DoJI823D/oVo0/Pk3SjZMcZFkK65JnO1roU3gT2zXYa9/ndIVnJomYwhGb7DHElGeXjlAvJccd Uy2O++/6toO3Qr0dolnGXHXNVG1B40Q2mshs2f68H29kNmduzyDfZhR+hCCBXih2nLn09Pp5E5p 4w2BvEa5bfnrRrOkd4pnKHmSog==
+X-Originalarrivaltime: 29 Sep 2011 07:48:51.0471 (UTC) FILETIME=[3AD0D1F0:01CC7E7C]
+X-Tm-As-User-Blocked-Sender: No

--- a/tests/__files/broken_header-expected-html.txt
+++ b/tests/__files/broken_header-expected-html.txt
@@ -1,0 +1,169 @@
+<html dir=3D"ltr">
+    <head>
+        <title></title>
+    </head>
+    <body>
+        <span style=3D"font-size: 13px;"><span style=3D"font-family: Verdan=
+a;">Plb Group</span></span> <span style=3D"font-size: 13px;"><span style=3D=
+"font-family: Verdana;">Events presents: <br>
+        <strong><span style=3D"font-size: 14px;">Overcoming the Olympic Hur=
+dle</span></strong><br>
+        <br>
+        A one-day masterclass to help you minimise disruption to your busin=
+ess<br>
+        20th October 2011<br>
+        Central London<br>
+        <br>
+        <strong>TODAY&nbsp;ONLY:&nbsp;&pound;395+VAT. (usual price &pound;4=
+95+VAT). <a href=3D"mailto:events@example.com?subject=3DBOOKING%20-%20Olymp=
+ic%20Hurdle%20(1865)&body=3DPlease%20book%20me%20a%20place%20for%20Olympic%=
+20Hurdle%20-%20%C2%A3395%2BVAT%0A%0AMy%20details%20are%20as%20follows%3A">C=
+lick here to book a place</a></strong><br>
+        <br>
+        Dear Helen,<br>
+        <br>
+        With London estimated to receive 5.5 million visitors during next y=
+ear's Olympic games there are significant risks to your business: <br>
+        </span><span style=3D"font-size: 10pt; font-family: Verdana;"><br>
+        - Staff travel<br>
+        - Client availability and ability to attend meetings<br>
+        - Supplier delivery delays and limited access to central London<br>
+        - Staff absences as a result of attending the games<br>
+        - The practicality and procedures of remote working<br>
+        </span></span><span style=3D"font-size: 13px;"><span style=3D"font-=
+family: Verdana;"><br>
+        Now  is the time to decide on your business continuity plan for the=
+ six  weeks that the Olympics and Paralympics will be taking place.<br>
+        </span></span><span style=3D"font-size: 13px;"><span style=3D"font-=
+size: 10pt; font-family: Verdana;"><br>
+        </span></span><!--[if gte mso 9]><xml>
+        <w:WordDocument>
+        <w:View>Normal</w:View>
+        <w:Zoom>0</w:Zoom>
+        <w:PunctuationKerning>
+        <w:ValidateAgainstSchemas>
+        <w:SaveIfXMLInvalid>false</w:SaveIfXMLInvalid>
+        <w:IgnoreMixedContent>false</w:IgnoreMixedContent>
+        <w:AlwaysShowPlaceholderText>false</w:AlwaysShowPlaceholderText>
+        <w:Compatibility>
+        <w:BreakWrappedTables>
+        <w:SnapToGridInCell>
+        <w:WrapTextWithPunct>
+        <w:UseAsianBreakRules>
+        <w:DontGrowAutofit>
+        </w:Compatibility>
+        <w:BrowserLevel>MicrosoftInternetExplorer4</w:BrowserLevel>
+        </w:WordDocument>
+        </xml><![endif]--><!--[if gte mso 9]><xml>
+        <w:LatentStyles DefLockedState=3D"false" LatentStyleCount=3D"156">
+        </w:LatentStyles>
+        </xml><![endif]--><!--[if !mso]><object
+        classid=3D"clsid:38481807-CA0E-42D2-BF39-B33AF135CC4D" id=3Dieooui>=
+</object>
+        <style>
+        st1\:*{behavior:url(#ieooui) }
+        </style>
+        <![endif]--><!--[if gte mso 10]>
+        <style>
+        /* Style Definitions */
+        table.MsoNormalTable
+        {mso-style-name:"Table Normal";
+        mso-tstyle-rowband-size:0;
+        mso-tstyle-colband-size:0;
+        mso-style-noshow:yes;
+        mso-style-parent:"";
+        mso-padding-alt:0cm 5.4pt 0cm 5.4pt;
+        mso-para-margin:0cm;
+        mso-para-margin-bottom:.0001pt;
+        mso-pagination:widow-orphan;
+        font-size:10.0pt;
+        font-family:"Times New Roman";
+        mso-ansi-language:#0400;
+        mso-fareast-language:#0400;
+        mso-bidi-language:#0400;}
+        </style>
+        <![endif]-->                  <span style=3D"font-size: 13px;"><spa=
+n style=3D"font-family: Verdana;">                  The increased pressure =
+on transport and services will be an issue for your company if you don&rsqu=
+o;t plan correctly. During this masterclass you will have the opportunity t=
+o strategically ensure your company is not adversely impacted by the Olympi=
+cs; you will also have the opportunity to pose questions and work through s=
+olutions which will be unique to your own organisational situation.<br>
+        <br>
+        </span></span><strong><span style=3D"font-size: 13px;"><span style=
+=3D"font-family: Verdana;"><br>
+        </span></span></strong><span style=3D"font-family: Verdana;"><span =
+style=3D"font-size: 13px;"><span style=3D"font-size: 10pt;">If you are a Ma=
+naging Director</span></span>,<span style=3D"font-size: 13px;"> Senior Mana=
+ger, Head of Risk, Head of HR or </span></span><span style=3D"font-family: =
+Verdana;"><span style=3D"font-size: 13px;">Head of IT</span></span><span st=
+yle=3D"font-family: Verdana;">      <span style=3D"font-size: 13px;">      =
+   from any size business in or around an Olympic location </span></span><s=
+trong><span style=3D"font-family: Verdana;"><span style=3D"font-size: 13px;=
+">you need to attend this event.</span></span></strong><span style=3D"font-=
+size: 13px;"><span style=3D"font-family: Verdana;"><br>
+        </span></span><span style=3D"font-size: 13px;"><span style=3D"font-=
+family: Verdana;"><br>
+        </span></span><span style=3D"font-size: 13px;"><span style=3D"font-=
+family: Verdana;"><br>
+        <strong>TODAY&nbsp;ONLY:&nbsp;&pound;395+VAT. (usual price &pound;4=
+95+VAT). <a href=3D"mailto:events@example.com?subject=3DBOOKING%20-%20Olymp=
+ic%20Hurdle%20(1865)&body=3DPlease%20book%20me%20a%20place%20for%20Olympic%=
+20Hurdle%20-%20%C2%A3395%2BVAT%0A%0AMy%20details%20are%20as%20follows%3A">C=
+lick here to book a place</a></strong></span></span><span style=3D"font-siz=
+e: 13px;"><span style=3D"font-family: Verdana;"><br>
+        <br>
+        <strong>Agenda: </strong><br>
+        <br>
+        <strong>9:00 Registration and refreshments</strong><br>
+        <br>
+        <strong>9:30 Understanding the 2012 Olympics challenge</strong><br>
+        <br>
+        &bull;&nbsp;&nbsp; &nbsp;Delegate introductions and objectives for =
+the day<br>
+        &bull;&nbsp;&nbsp; &nbsp;Overview of the size and scale of the game=
+s<br>
+        &bull;&nbsp;&nbsp; &nbsp;The potential for business interruption<br=
+>
+        <br>
+        <strong>10:10 Threats, Vulnerabilities and Impacts</strong><br>
+        <br>
+        &bull;&nbsp;&nbsp; &nbsp;What are the threats to your business?<br>
+        &bull;&nbsp;&nbsp; &nbsp;What are the long term consequences of not=
+ dealing with them?<br>
+        &bull;&nbsp;&nbsp; &nbsp;How vulnerable is your location?<br>
+        &bull;&nbsp;&nbsp; &nbsp;How resilient are you to the type of disru=
+ption you might face?<br>
+        <br>
+        16:30 Close of masterclass</strong><br>
+        </span></span><span style=3D"font-size: 13px;"><span style=3D"font-=
+family: Verdana;"><br>
+        <strong>TODAY&nbsp;ONLY:&nbsp;&pound;395+VAT. (usual price &pound;4=
+95+VAT). <a href=3D"mailto:events@example.com?subject=3DBOOKING%20-%20Olymp=
+ic%20Hurdle%20(1865)&body=3DPlease%20book%20me%20a%20place%20for%20Olympic%=
+20Hurdle%20-%20%C2%A3395%2BVAT%0A%0AMy%20details%20are%20as%20follows%3A">C=
+lick here to book a place</a></strong></span></span><span style=3D"font-siz=
+e: 13px;"><span style=3D"font-family: Verdana;">. Alternatively <strong>cal=
+l +44 (0)207 566 5792</strong> to speak to our customer service team<br>
+        <br>
+        For more information of group discounts <a href=3D"mailto:events@ar=
+k-group.com?subject=3DGroup%20Booking%20-%20Olympic%20Hurdle%20(1865)&body=
+=3DTell%20me%20more"><strong>email us</strong></a><br>
+        <br>
+        For more information on our events <strong>visit <a  href=3D"http:/=
+/mxm.example.com/rsps/ct/c/126/r/253989/l/182347" >www.example.com</a></str=
+ong><br>
+        <br>
+        <a href=3D"http://mxm.example.com/rsps/unsb/c/126/r/253989/l/182349=
+" target=3D"__blank">unsubscribe</a><br>
+        <br>
+        <br>
+        <span style=3D"font-size: 11px;">A division of WILMINGTON GROUP plc=
+ <br>
+        Registered Office: 19 &ndash; 21 Christopher Street, London, EC2A 2=
+BS<br>
+        Company Registration number: 2931372 </span><br>
+        </span></span><br>
+    <img src=3D"http://mxm.example.com/rsps/img/c/126/r/253989/e/15041/i/s.=
+gif" visible=3D"false" width=3D"0" height=3D"0" border=3D"0" /></body>
+</html>

--- a/tests/__files/broken_header-source.eml
+++ b/tests/__files/broken_header-source.eml
@@ -1,0 +1,212 @@
+Received: from gbnthda3150srv.example.com ([10.67.121.52]) by GBLONVMSX001.nsicorp.int with Microsoft SMTPSVC(6.0.3790.4675);
+	 Thu, 29 Sep 2011 08:48:51 +0100
+Received: from localhost (unknown [127.0.0.1])
+	by IMSVA80 (Postfix) with SMTP id E307622003E
+	for <recipient@example.com>; Thu, 29 Sep 2011 08:48:58 +0100 (BST)
+Received: from mta6551.example.com (unknown [109.68.65.51])
+	by gbnthda3150srv.example.com (Postfix) with ESMTP id 6F72A220057
+	for <recipient@example.com>; Fri, 23 Sep 2011 09:54:25 +0100 (BST)
+Received: by mta6551.example.com (PowerMTA(TM) v3.5r14) id hfh4js0sv5km for <recipient@example.com>; Fri, 23 Sep 2011 09:54:22 +0100 (envelope-from <bounce-100-250-1831-live@mail.example.com>)
+From: "Events" <eventmarketing@example.com>
+Reply-To: "Events" <eventmarketing@example.com>
+X-Mailer: MXM-v5-MailEngine
+To: recipient@example.com
+Subject: =?utf-8?B?W+uwnOyGoeyLpO2MqCDslYjrgrRdIGhlYXlldW4xMjM0QG5hdmVy?=
+ =?utf-8?B?LmNvbSDsnLzroZwg66mU7J287J20IOyghOyGoeuQmOyngCDrqrvt?=
+ =?utf-8?B?lojsirXri4jri6Qu?=
+Message-ID: <0.0.24D.2F1.1CC79CE6346CBD8.0@mta6551.example.com>
+Date: Fri, 23 Sep 2011 09:54:22 +0100
+X-TM-AS-Product-Ver: SMEX-8.0.0.1181-6.500.1024-18336.002
+X-TM-AS-Result: No--4.601200-8.000000-31
+X-imss-scan-details: No--12.138-5.0-31-10
+X-TM-AS-User-Approved-Sender: No
+X-TM-AS-Result-Xfilter: Match text exemption rules:No
+X-TMASE-MatchedRID: Q2+zkeG6t3p+YGzLN7T7mqGIP6nmLu6LLw30/c3NkEDNcm2bW2t5nPvA
+	DvTnCf5vDYBVKmbeeQOVIU9/CM32kdWn59xnE0iHoMd8fz60W5eYrH5+aA00En4WoLVkiF5MrDF
+	tme53KvtDGFvBeB2nXEK7eJQWtfQOGbNuSeNqcN92KN90fG2iIujLQmIoVnOSG1CvAg7R8yRFxL
+	gyMr3q0aFI/hOhKe2if7FDYGpyXq3img94X0eg/ol1yzEgrR9NPGMCwqTcrWssXJM82Uy2JgQYC
+	cQrwdJfGSqdEmeD/nVEm2z04jGoEw1UcnuLpxYgVQqcStBKJr9uLA60aUCmmFVBWgEsQzu09Szz
+	aTBwGVB52IkwyV1HePn4mcXPgnU12UI6LaiL1lWZYZEz3zbAyntZCpfMKy9fNLOElW08UrbU3m2
+	KoscyCyz67EO943zmJKoUzP1GfbbbTWWstzOlSzW9LFay9u07Cbx7yn3FMqIDf5+W2YF4RXYiw8
+	L1nrYYh+w9Wz/xXDptPXRTHBlYsAIxQkXDtNe7Da6S/pucmjtaiKNTrM3yG19IvYJOgu3ChDqIQ
+	b7sQeeO74ZfTyAQsL6nzxSJcwn0YZPliWGvyajMgKQ8B6MJ9cKjqJxyhMunKMLj+jsQyO/wI5Ez
+	JETTVCI9VGugnfROACF5TKaad195Jkx0cWUhes4ygPHg/CeBfk8FD2cg0j/trubt8TkL4ZQ7SU/
+	QtiDSa/fioJ9l4HhhV/XBZzYTCF8baTVx8DUoCOVnyuVVgerk/4xeauuY7zo7wMLyyGiGIj0zFI
+	5DoJI823D/oVo0/Pk3SjZMcZFkK65JnO1roU3gT2zXYa9/ndIVnJomYwhGb7DHElGeXjlAvJccd
+	Uy2O++/6toO3Qr0dolnGXHXNVG1B40Q2mshs2f68H29kNmduzyDfZhR+hCCBXih2nLn09Pp5E5p
+	4w2BvEa5bfnrRrOkd4pnKHmSog==
+Return-Path: bounce-100-250-1831-live@mail.example.com
+X-OriginalArrivalTime: 29 Sep 2011 07:48:51.0471 (UTC) FILETIME=[3AD0D1F0:01CC7E7C]
+X-TM-AS-User-Blocked-Sender: No
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+<html dir=3D"ltr">
+    <head>
+        <title></title>
+    </head>
+    <body>
+        <span style=3D"font-size: 13px;"><span style=3D"font-family: Verdan=
+a;">Plb Group</span></span> <span style=3D"font-size: 13px;"><span style=3D=
+"font-family: Verdana;">Events presents: <br>
+        <strong><span style=3D"font-size: 14px;">Overcoming the Olympic Hur=
+dle</span></strong><br>
+        <br>
+        A one-day masterclass to help you minimise disruption to your busin=
+ess<br>
+        20th October 2011<br>
+        Central London<br>
+        <br>
+        <strong>TODAY&nbsp;ONLY:&nbsp;&pound;395+VAT. (usual price &pound;4=
+95+VAT). <a href=3D"mailto:events@example.com?subject=3DBOOKING%20-%20Oly=
+mpic%20Hurdle%20(1865)&body=3DPlease%20book%20me%20a%20place%20for%20Olympi=
+c%20Hurdle%20-%20%C2%A3395%2BVAT%0A%0AMy%20details%20are%20as%20follows%3A"=
+>Click here to book a place</a></strong><br>
+        <br>
+        Dear Helen,<br>
+        <br>
+        With London estimated to receive 5.5 million visitors during next y=
+ear's Olympic games there are significant risks to your business: <br>
+        </span><span style=3D"font-size: 10pt; font-family: Verdana;"><br>
+        - Staff travel<br>
+        - Client availability and ability to attend meetings<br>
+        - Supplier delivery delays and limited access to central London<br>
+        - Staff absences as a result of attending the games<br>
+        - The practicality and procedures of remote working<br>
+        </span></span><span style=3D"font-size: 13px;"><span style=3D"font-=
+family: Verdana;"><br>
+        Now  is the time to decide on your business continuity plan for the=
+ six  weeks that the Olympics and Paralympics will be taking place.<br>
+        </span></span><span style=3D"font-size: 13px;"><span style=3D"font-=
+size: 10pt; font-family: Verdana;"><br>
+        </span></span><!--[if gte mso 9]><xml>
+        <w:WordDocument>
+        <w:View>Normal</w:View>
+        <w:Zoom>0</w:Zoom>
+        <w:PunctuationKerning>
+        <w:ValidateAgainstSchemas>
+        <w:SaveIfXMLInvalid>false</w:SaveIfXMLInvalid>
+        <w:IgnoreMixedContent>false</w:IgnoreMixedContent>
+        <w:AlwaysShowPlaceholderText>false</w:AlwaysShowPlaceholderText>
+        <w:Compatibility>
+        <w:BreakWrappedTables>
+        <w:SnapToGridInCell>
+        <w:WrapTextWithPunct>
+        <w:UseAsianBreakRules>
+        <w:DontGrowAutofit>
+        </w:Compatibility>
+        <w:BrowserLevel>MicrosoftInternetExplorer4</w:BrowserLevel>
+        </w:WordDocument>
+        </xml><![endif]--><!--[if gte mso 9]><xml>
+        <w:LatentStyles DefLockedState=3D"false" LatentStyleCount=3D"156">
+        </w:LatentStyles>
+        </xml><![endif]--><!--[if !mso]><object
+        classid=3D"clsid:38481807-CA0E-42D2-BF39-B33AF135CC4D" id=3Dieooui>=
+</object>
+        <style>
+        st1\:*{behavior:url(#ieooui) }
+        </style>
+        <![endif]--><!--[if gte mso 10]>
+        <style>
+        /* Style Definitions */
+        table.MsoNormalTable
+        {mso-style-name:"Table Normal";
+        mso-tstyle-rowband-size:0;
+        mso-tstyle-colband-size:0;
+        mso-style-noshow:yes;
+        mso-style-parent:"";
+        mso-padding-alt:0cm 5.4pt 0cm 5.4pt;
+        mso-para-margin:0cm;
+        mso-para-margin-bottom:.0001pt;
+        mso-pagination:widow-orphan;
+        font-size:10.0pt;
+        font-family:"Times New Roman";
+        mso-ansi-language:#0400;
+        mso-fareast-language:#0400;
+        mso-bidi-language:#0400;}
+        </style>
+        <![endif]-->                  <span style=3D"font-size: 13px;"><spa=
+n style=3D"font-family: Verdana;">                  The increased pressure =
+on transport and services will be an issue for your company if you don&rsqu=
+o;t plan correctly. During this masterclass you will have the opportunity t=
+o strategically ensure your company is not adversely impacted by the Olympi=
+cs; you will also have the opportunity to pose questions and work through s=
+olutions which will be unique to your own organisational situation.<br>
+        <br>
+        </span></span><strong><span style=3D"font-size: 13px;"><span style=
+=3D"font-family: Verdana;"><br>
+        </span></span></strong><span style=3D"font-family: Verdana;"><span =
+style=3D"font-size: 13px;"><span style=3D"font-size: 10pt;">If you are a Ma=
+naging Director</span></span>,<span style=3D"font-size: 13px;"> Senior Mana=
+ger, Head of Risk, Head of HR or </span></span><span style=3D"font-family: =
+Verdana;"><span style=3D"font-size: 13px;">Head of IT</span></span><span st=
+yle=3D"font-family: Verdana;">      <span style=3D"font-size: 13px;">      =
+   from any size business in or around an Olympic location </span></span><s=
+trong><span style=3D"font-family: Verdana;"><span style=3D"font-size: 13px;=
+">you need to attend this event.</span></span></strong><span style=3D"font-=
+size: 13px;"><span style=3D"font-family: Verdana;"><br>
+        </span></span><span style=3D"font-size: 13px;"><span style=3D"font-=
+family: Verdana;"><br>
+        </span></span><span style=3D"font-size: 13px;"><span style=3D"font-=
+family: Verdana;"><br>
+        <strong>TODAY&nbsp;ONLY:&nbsp;&pound;395+VAT. (usual price &pound;4=
+95+VAT). <a href=3D"mailto:events@example.com?subject=3DBOOKING%20-%20Oly=
+mpic%20Hurdle%20(1865)&body=3DPlease%20book%20me%20a%20place%20for%20Olympi=
+c%20Hurdle%20-%20%C2%A3395%2BVAT%0A%0AMy%20details%20are%20as%20follows%3A"=
+>Click here to book a place</a></strong></span></span><span style=3D"font-s=
+ize: 13px;"><span style=3D"font-family: Verdana;"><br>
+        <br>
+        <strong>Agenda: </strong><br>
+        <br>
+        <strong>9:00 Registration and refreshments</strong><br>
+        <br>
+        <strong>9:30 Understanding the 2012 Olympics challenge</strong><br>
+        <br>
+        &bull;&nbsp;&nbsp; &nbsp;Delegate introductions and objectives for =
+the day<br>
+        &bull;&nbsp;&nbsp; &nbsp;Overview of the size and scale of the game=
+s<br>
+        &bull;&nbsp;&nbsp; &nbsp;The potential for business interruption<br=
+>
+        <br>
+        <strong>10:10 Threats, Vulnerabilities and Impacts</strong><br>
+        <br>
+        &bull;&nbsp;&nbsp; &nbsp;What are the threats to your business?<br>
+        &bull;&nbsp;&nbsp; &nbsp;What are the long term consequences of not=
+ dealing with them?<br>
+        &bull;&nbsp;&nbsp; &nbsp;How vulnerable is your location?<br>
+        &bull;&nbsp;&nbsp; &nbsp;How resilient are you to the type of disru=
+ption you might face?<br>
+        <br>
+        16:30 Close of masterclass</strong><br>
+        </span></span><span style=3D"font-size: 13px;"><span style=3D"font-=
+family: Verdana;"><br>
+        <strong>TODAY&nbsp;ONLY:&nbsp;&pound;395+VAT. (usual price &pound;4=
+95+VAT). <a href=3D"mailto:events@example.com?subject=3DBOOKING%20-%20Oly=
+mpic%20Hurdle%20(1865)&body=3DPlease%20book%20me%20a%20place%20for%20Olympi=
+c%20Hurdle%20-%20%C2%A3395%2BVAT%0A%0AMy%20details%20are%20as%20follows%3A"=
+>Click here to book a place</a></strong></span></span><span style=3D"font-s=
+ize: 13px;"><span style=3D"font-family: Verdana;">. Alternatively <strong>c=
+all +44 (0)207 566 5792</strong> to speak to our customer service team<br>
+        <br>
+        For more information of group discounts <a href=3D"mailto:events@ar=
+k-group.com?subject=3DGroup%20Booking%20-%20Olympic%20Hurdle%20(1865)&body=
+=3DTell%20me%20more"><strong>email us</strong></a><br>
+        <br>
+        For more information on our events <strong>visit <a  href=3D"http:/=
+/mxm.example.com/rsps/ct/c/126/r/253989/l/182347" >www.example.com</a></str=
+ong><br>
+        <br>
+        <a href=3D"http://mxm.example.com/rsps/unsb/c/126/r/253989/l/182349" =
+target=3D"__blank">unsubscribe</a><br>
+        <br>
+        <br>
+        <span style=3D"font-size: 11px;">A division of WILMINGTON GROUP plc=
+ <br>
+        Registered Office: 19 &ndash; 21 Christopher Street, London, EC2A 2=
+BS<br>
+        Company Registration number: 2931372 </span><br>
+        </span></span><br>
+    <img src=3D"http://mxm.example.com/rsps/img/c/126/r/253989/e/15041/i/s.gi=
+f" visible=3D"false" width=3D"0" height=3D"0" border=3D"0" /></body>
+</html>


### PR DESCRIPTION
Skip parse errors to produce best possible mail object.

[RFC2047 § 6.3](https://www.ietf.org/rfc/rfc2047.txt) says that
> a mail reader MUST NOT prevent the display or handling of a message because an 'encoded-word' is incorrectly formed.

This will allow invalid, un-readable headers to be ignored and skipped, to produce the best possible representation of the raw message.

