### PR TITLE
Alter attachment to make name and disposition immutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Simplified result array for `Factory::decodeHeader()` to just contain the charset of the resulting string
+- **BC break**: Added *disposition* as a constructor argument for `Attachment`
+### Removed
+- **BC break**: Removed `Attachment::setName()` and
+  `Attachment::setDisposition()` to make the related parameters immutable
 
 ## [1.0.0] - 2017-02-07
 ### Added

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -271,7 +271,8 @@ class Factory
             if ($name != '1' && isset($partData['content-name'])) {
                 // It's an attachment
                 $mail->incrementAttachmentCount();
-                $mailPart = new Content\Attachment($partData['content-name'], $type);
+                $disposition = isset($partData['content-disposition']) ? $partData['content-disposition'] : null;
+                $mailPart = new Content\Attachment($partData['content-name'], $disposition, $type);
                 if (isset($partData['content-charset'])) {
                     $mailPart->setCharset($partData['content-charset']);
                 }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -295,7 +295,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
                 $this->assertContains($contentType, $partHeaders);
                 if ($details['disposition'] === true) {
                     $this->assertContains(
-                        'Content-Disposition: attachment; filename=' . $details['name'],
+                        'Content-Disposition: attachment; filename="' . $details['name'] . '"',
                         $partHeaders
                     );
                 } else {


### PR DESCRIPTION
Main aim is to make *disposition* part of the Attachment constructor requirements, rather than allow a generic header to skip the existing disposition code.

Removing the public methods too, to make these parameters immutable.