### PR TITLE
Fix encoding in address headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Add encoding for address headers (To, Cc, Reply-To) which was lost in 2.0.0
 
 ## [2.0.0]
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "ext-mbstring": "*"
     },
     "require-dev": {
+        "ext-iconv" : "*",
         "phpunit/phpunit": "~4.4"
     },
     "autoload": {

--- a/src/Mail.php
+++ b/src/Mail.php
@@ -120,7 +120,7 @@ class Mail extends AbstractPart
             foreach ($this->to as $address => $name) {
                 $to[] = $this->formatAddress($address, $name);
             }
-            $headers[] = 'To: ' . rtrim(implode(",\r\n ", $to));
+            $headers[] = $this->encodeHeader('To: ' . rtrim(implode(",\r\n ", $to)));
         }
 
         if (!empty($this->cc)) {
@@ -128,12 +128,12 @@ class Mail extends AbstractPart
             foreach ($this->cc as $address => $name) {
                 $cc[] = $this->formatAddress($address, $name);
             }
-            $headers[] = 'Cc: ' . rtrim(implode(",\r\n ", $cc));
+            $headers[] = $this->encodeHeader('Cc: ' . rtrim(implode(",\r\n ", $cc)));
         }
 
         if ($this->replyTo) {
             list($address, $name) = $this->replyTo;
-            $headers[] = 'Reply-To: ' . $this->formatAddress($address, $name);
+            $headers[] = $this->encodeHeader('Reply-To: ' . $this->formatAddress($address, $name));
         }
 
         if ($this->getPart() instanceof Mime\AbstractMime) {


### PR DESCRIPTION
To, Cc, Reply-To were missing encoding for special chars

Regression introduced in v2.0.0

This will be for immediate v2.0.1