### PR TITLE
Fix Mail property defaults and docblocks to match getter behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Clarify the return type for the following `Mail` methods to show they can be
+null if not set: `getFrom()`, `getReplyTo()`, `getReturnPath()`, `getSubject()` 
 
 ## [2.0.3]
 ### Changed

--- a/src/Mail.php
+++ b/src/Mail.php
@@ -33,9 +33,9 @@ class Mail extends AbstractPart
     ];
 
     /**
-     * @var string
+     * @var string|null
      */
-    private $subject = null;
+    private $subject;
 
     /**
      * @var array
@@ -43,9 +43,9 @@ class Mail extends AbstractPart
     private $to = [];
 
     /**
-     * @var string
+     * @var array|null
      */
-    private $from = null;
+    private $from;
 
     /**
      * @var array
@@ -53,14 +53,14 @@ class Mail extends AbstractPart
     private $cc = [];
 
     /**
-     * @var string
+     * @var array|null
      */
-    private $replyTo = null;
+    private $replyTo;
 
     /**
-     * @var string
+     * @var string|null
      */
-    private $returnPath = null;
+    private $returnPath;
 
     /**
      * @var int The number of attachments in any of this mail's descendants
@@ -259,7 +259,7 @@ class Mail extends AbstractPart
     /**
      * Get reply to
      *
-     * @return array
+     * @return array|null
      */
     public function getReplyTo()
     {
@@ -316,7 +316,7 @@ class Mail extends AbstractPart
     /**
      * Get return path
      *
-     * @return string
+     * @return string|null
      */
     public function getReturnPath()
     {
@@ -349,7 +349,7 @@ class Mail extends AbstractPart
     /**
      * Get from
      *
-     * @return array
+     * @return array|null
      */
     public function getFrom()
     {
@@ -371,7 +371,7 @@ class Mail extends AbstractPart
     /**
      * Get subject
      *
-     * @return string
+     * @return string|null
      */
     public function getSubject()
     {


### PR DESCRIPTION
I've gone for `null` rather than an empty value of the relevant type, because that's in-keeping with the current behaviour, and Mxm has some validation checks for `is_array()` for `getFrom()` and `getReplyTo()` rather than just `!empty()`