### PR TITLE
Tidy unit tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php"
          beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutCoversAnnotation="true"
          beStrictAboutOutputDuringTests="true"
          colors="true">
     <testsuites>

--- a/tests/AbstractPartTest.php
+++ b/tests/AbstractPartTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phlib\Tests\Mail;
+namespace Phlib\Mail\Tests;
 
 use Phlib\Mail\AbstractPart;
 use Phlib\Mail\Exception\InvalidArgumentException;

--- a/tests/AbstractPartTest.php
+++ b/tests/AbstractPartTest.php
@@ -3,6 +3,7 @@
 namespace Phlib\Tests\Mail;
 
 use Phlib\Mail\AbstractPart;
+use Phlib\Mail\Exception\InvalidArgumentException;
 
 class AbstractPartTest extends \PHPUnit_Framework_TestCase
 {
@@ -35,22 +36,22 @@ class AbstractPartTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage invalid name
-     */
     public function testAddHeaderInvalidName()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('invalid name');
+
         $this->part->addHeader('invalid name', 'value');
     }
 
     /**
      * @dataProvider dataAddHeaderProhibitedName
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Header name is prohibited
      */
     public function testAddHeaderProhibitedName($name)
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Header name is prohibited');
+
         $this->part->addHeader($name, 'value');
     }
 
@@ -171,10 +172,10 @@ class AbstractPartTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider dataSetGetEncodingInvalid
-     * @expectedException \InvalidArgumentException
      */
     public function testSetGetEncodingInvalid($encoding)
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->part->setEncoding($encoding);
     }
 

--- a/tests/Content/AbstractContentTest.php
+++ b/tests/Content/AbstractContentTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phlib\Tests\Mail\Content;
+namespace Phlib\Mail\Tests\Content;
 
 use Phlib\Mail\AbstractPart;
 use Phlib\Mail\Content\AbstractContent;

--- a/tests/Content/AttachmentTest.php
+++ b/tests/Content/AttachmentTest.php
@@ -4,6 +4,7 @@ namespace Phlib\Tests\Mail\Content;
 
 use Phlib\Mail\AbstractPart;
 use Phlib\Mail\Content\Attachment;
+use Phlib\Mail\Exception\InvalidArgumentException;
 
 class AttachmentTest extends \PHPUnit_Framework_TestCase
 {
@@ -30,12 +31,11 @@ class AttachmentTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @expectedException \Phlib\Mail\Exception\InvalidArgumentException
-     * @expectedExceptionMessage file cannot be read
-     */
     public function testCreateFromFileInvalid()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('file cannot be read');
+
         Attachment::createFromFile('path/to/invalid/file.txt');
     }
 
@@ -70,10 +70,10 @@ class AttachmentTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider dataSetGetEncodingInvalid
-     * @expectedException \InvalidArgumentException
      */
     public function testSetGetEncodingInvalid($encoding)
     {
+        $this->expectException(InvalidArgumentException::class);
         $part = new Attachment('example-file-name.png');
         $part->setEncoding($encoding);
     }

--- a/tests/Content/AttachmentTest.php
+++ b/tests/Content/AttachmentTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phlib\Tests\Mail\Content;
+namespace Phlib\Mail\Tests\Content;
 
 use Phlib\Mail\AbstractPart;
 use Phlib\Mail\Content\Attachment;

--- a/tests/Content/ContentTest.php
+++ b/tests/Content/ContentTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phlib\Tests\Mail\Content;
+namespace Phlib\Mail\Tests\Content;
 
 use Phlib\Mail\Content\Content;
 

--- a/tests/Content/HtmlTest.php
+++ b/tests/Content/HtmlTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phlib\Tests\Mail\Content;
+namespace Phlib\Mail\Tests\Content;
 
 use Phlib\Mail\Content\Html;
 

--- a/tests/Content/TextTest.php
+++ b/tests/Content/TextTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phlib\Tests\Mail\Content;
+namespace Phlib\Mail\Tests\Content;
 
 use Phlib\Mail\Content\Text;
 

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -27,6 +27,11 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     /**
      * Prevent giving code coverage to the Mail classes
      * @covers \Phlib\Mail\Factory
+     * @uses \Phlib\Mail\AbstractPart
+     * @uses \Phlib\Mail\Content\AbstractContent
+     * @uses \Phlib\Mail\Content\Attachment
+     * @uses \Phlib\Mail\Mail
+     * @uses \Phlib\Mail\Mime\AbstractMime
      */
     public function testCreateFromFileAttachments()
     {
@@ -43,6 +48,9 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     /**
      * Prevent giving code coverage to the Mail classes
      * @covers \Phlib\Mail\Factory
+     * @uses \Phlib\Mail\Content\Attachment<extended>
+     * @uses \Phlib\Mail\Mail
+     * @uses \Phlib\Mail\Mime\AbstractMime
      */
     public function testCreateFromStringAttachments()
     {
@@ -59,6 +67,9 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     /**
      * Prevent giving code coverage to the Mail classes
      * @covers \Phlib\Mail\Factory
+     * @uses \Phlib\Mail\Content\Content<extended>
+     * @uses \Phlib\Mail\Mail
+     * @uses \Phlib\Mail\Mime\MultipartReport<extended>
      */
     public function testCreateFromFileBounceHead()
     {
@@ -75,6 +86,9 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     /**
      * Prevent giving code coverage to the Mail classes
      * @covers \Phlib\Mail\Factory
+     * @uses \Phlib\Mail\Content\Content<extended>
+     * @uses \Phlib\Mail\Mail
+     * @uses \Phlib\Mail\Mime\MultipartReport<extended>
      */
     public function testCreateFromFileBounceMsg()
     {
@@ -89,6 +103,8 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     /**
      * Prevent giving code coverage to the Mail classes
      * @covers \Phlib\Mail\Factory
+     * @uses \Phlib\Mail\Content\AbstractContent<extended>
+     * @uses \Phlib\Mail\Mail
      */
     public function testCreateFromFileHtml()
     {
@@ -103,6 +119,8 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     /**
      * Prevent giving code coverage to the Mail classes
      * @covers \Phlib\Mail\Factory
+     * @uses \Phlib\Mail\Content\AbstractContent<extended>
+     * @uses \Phlib\Mail\Mail
      * @requires PHP 5.4.17
      * see http://bugs.php.net/64166 this change appears to have affected the expected output from
      * quoted_printable_encode between PHP versions

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -231,7 +231,8 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     {
         $warningMsg = 'Couldn\'t get the part';
 
-        $this->setExpectedException(RuntimeException::class, $warningMsg);
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage($warningMsg);
 
         $mailparse_msg_get_part = $this->getFunctionMock('\Phlib\Mail', 'mailparse_msg_get_part');
         $mailparse_msg_get_part->expects($this->once())

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phlib\Tests\Mail;
+namespace Phlib\Mail\Tests;
 
 use Phlib\Mail\Content\Attachment;
 use Phlib\Mail\Content\Content;

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -3,6 +3,8 @@
 namespace Phlib\Tests\Mail;
 
 use Phlib\Mail\Content\Content;
+use Phlib\Mail\Exception\InvalidArgumentException;
+use Phlib\Mail\Exception\RuntimeException;
 use Phlib\Mail\Mail;
 use Phlib\Mail\Mime\Mime;
 
@@ -34,11 +36,9 @@ class MailTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($part, $this->mail->getPart());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testGetPartNotSet()
     {
+        $this->expectException(RuntimeException::class);
         $this->mail->getPart();
     }
 
@@ -68,11 +68,10 @@ class MailTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, iconv_mime_decode_headers($this->mail->getEncodedHeaders()));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testGetEncodedHeadersNotSet()
     {
+        $this->expectException(RuntimeException::class);
+
         $expected = "";
         $this->assertEquals($expected, $this->mail->getEncodedHeaders());
     }
@@ -90,11 +89,9 @@ class MailTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($data, $this->mail->getTo());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testAddToInvalid()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->mail->addTo('invalid address');
     }
 
@@ -122,11 +119,9 @@ class MailTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($data, $this->mail->getCc());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testAddCcInvalid()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->mail->addCc('invalid address');
     }
 
@@ -152,11 +147,9 @@ class MailTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($data, $this->mail->getReplyTo());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testSetReplyToInvalid()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->mail->setReplyTo('invalid address');
     }
 
@@ -168,11 +161,9 @@ class MailTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($address, $this->mail->getReturnPath());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testSetReturnPathInvalid()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->mail->setReturnPath('invalid address');
     }
 
@@ -197,11 +188,9 @@ class MailTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($data, $this->mail->getFrom());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testSetFromInvalid()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->mail->setFrom('invalid address');
     }
 

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phlib\Tests\Mail;
+namespace Phlib\Mail\Tests;
 
 use Phlib\Mail\Content\Content;
 use Phlib\Mail\Exception\InvalidArgumentException;

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -44,6 +44,7 @@ class MailTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers \Phlib\Mail\Mail
+     * @uses \Phlib\Mail\Content\Content<extended>
      */
     public function testGetEncodedHeaders()
     {
@@ -56,6 +57,7 @@ class MailTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers \Phlib\Mail\Mail
+     * @uses \Phlib\Mail\Mime\Mime<extended>
      */
     public function testGetEncodedHeadersWithData()
     {
@@ -277,6 +279,7 @@ class MailTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers \Phlib\Mail\Mail
+     * @uses \Phlib\Mail\Content\Content<extended>
      */
     public function testToString()
     {

--- a/tests/Mime/AbstractMimeTest.php
+++ b/tests/Mime/AbstractMimeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phlib\Tests\Mail\Mime;
+namespace Phlib\Mail\Tests\Mime;
 
 use Phlib\Mail\Mime\AbstractMime;
 

--- a/tests/Mime/AbstractMimeTest.php
+++ b/tests/Mime/AbstractMimeTest.php
@@ -85,7 +85,9 @@ class AbstractMimeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Phlib\Mail\Mime\AbstractMime::toString
+     * @covers \Phlib\Mail\Mime\AbstractMime::toString
+     * @uses \Phlib\Mail\Content\AbstractContent<extended>
+     * @uses \Phlib\Mail\Mime\AbstractMime<extended>
      */
     public function testToString()
     {

--- a/tests/Mime/MimeTest.php
+++ b/tests/Mime/MimeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phlib\Tests\Mail\Mime;
+namespace Phlib\Mail\Tests\Mime;
 
 use Phlib\Mail\Mime\Mime;
 

--- a/tests/Mime/MultipartAlternativeTest.php
+++ b/tests/Mime/MultipartAlternativeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phlib\Tests\Mail\Mime;
+namespace Phlib\Mail\Tests\Mime;
 
 use Phlib\Mail\Mime\MultipartAlternative;
 

--- a/tests/Mime/MultipartMixedTest.php
+++ b/tests/Mime/MultipartMixedTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phlib\Tests\Mail\Mime;
+namespace Phlib\Mail\Tests\Mime;
 
 use Phlib\Mail\Mime\MultipartMixed;
 

--- a/tests/Mime/MultipartRelatedTest.php
+++ b/tests/Mime/MultipartRelatedTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phlib\Tests\Mail\Mime;
+namespace Phlib\Mail\Tests\Mime;
 
 use Phlib\Mail\Mime\MultipartRelated;
 

--- a/tests/Mime/MultipartReportTest.php
+++ b/tests/Mime/MultipartReportTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Phlib\Tests\Mail\Mime;
+namespace Phlib\Mail\Tests\Mime;
 
 use Phlib\Mail\Mime\MultipartReport;
 


### PR DESCRIPTION
Quick tidy-up to prepare for PHPUnit 6 (once PHP 5 support is dropped)

Update PHPUnit's exception expectations to use newer methods. Previous methods and docblocks are deprecated, and this makes sure the proper namespaced exceptions are matched.

Update PHPUnit CodeCoverage annotations to comply with strict requirements.