### PR TITLE
Deprecate factory methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ null if not set: `getFrom()`, `getReplyTo()`, `getReturnPath()`, `getSubject()`
 - `Factory::decodeHeader()` and `Factory::parseEmailAddresses()` should not have
 originally formed part of the public API, and will be removed in the next major
 version 
+- `Factory::fromFile()` and `Factory::fromString()` static methods will be
+removed in the next major version. Instead use `createFromFile()` and
+`createFromString()` to avoid statics and allow for the Factory to be used in
+dependency injection. 
 
 ## [2.0.3]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Clarify the return type for the following `Mail` methods to show they can be
-null if not set: `getFrom()`, `getReplyTo()`, `getReturnPath()`, `getSubject()` 
+null if not set: `getFrom()`, `getReplyTo()`, `getReturnPath()`, `getSubject()`
+### Deprecated
+- `Factory::decodeHeader()` and `Factory::parseEmailAddresses()` should not have
+originally formed part of the public API, and will be removed in the next major
+version 
 
 ## [2.0.3]
 ### Changed

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -328,6 +328,7 @@ class Factory
     /**
      * Decode header
      *
+     * @deprecated 2.1.0:3.0.0 Method should not have been available in the public interface
      * @param string $header Encoded header
      * @param string $charset Target charset. Optional. Default will use source charset where available.
      * @return array {
@@ -360,6 +361,7 @@ class Factory
     /**
      * Parse RFC 822 formatted email addresses string
      *
+     * @deprecated 2.1.0:3.0.0 Method should not have been available in the public interface
      * @see mailparse_rfc822_parse_addresses()
      * @param string $addresses
      * @return array 'display', 'address' and 'is_group'

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -52,6 +52,7 @@ class Factory
     }
 
     /**
+     * @deprecated 2.1.0:3.0.0 Use createFromFile() to avoid statics and allow for the Factory to be used in DI
      * @param string $filename
      * @return Mail
      */
@@ -83,6 +84,7 @@ class Factory
     }
 
     /**
+     * @deprecated 2.1.0:3.0.0 Use createFromString() to avoid statics and allow for the Factory to be used in DI
      * @param string $source
      * @return Mail
      */

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -134,8 +134,6 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testDecodeHeaderUtf8Base64()
     {
-        $factory = new Factory();
-
         $header = '=?UTF-8?B?TG9uZG9uIE9seW1waWNzOiBCdXNpbmVzcyBDb250aW4=?=' . "\r\n"
             . ' =?UTF-8?B?dWl0eSBQbGFuIC0gwqMxMDAgZGlzY291bnQgdG9kYXkgb25seSE=?=';
 
@@ -144,13 +142,12 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
             'text' => 'London Olympics: Business Continuity Plan - £100 discount today only!'
         ];
 
-        $this->assertEquals($expected, $factory->decodeHeader($header));
+        $actual = $this->invokeDecodeHeader($header);
+        $this->assertEquals($expected, $actual);
     }
 
     public function testDecodeHeaderIsoQ()
     {
-        $factory = new Factory();
-
         $header = '=?ISO-8859-1?Q?London Olympics: Business Continuity Plan - =A3100 discount today only!?=';
 
         $expected = [
@@ -158,13 +155,12 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
             'text' => 'London Olympics: Business Continuity Plan - £100 discount today only!'
         ];
 
-        $this->assertEquals($expected, $factory->decodeHeader($header));
+        $actual = $this->invokeDecodeHeader($header);
+        $this->assertEquals($expected, $actual);
     }
 
     public function testDecodeHeaderPart()
     {
-        $factory = new Factory();
-
         $header = 'London Olympics: Business Continuity Plan - =?ISO-8859-1?Q?=A3100?= discount today only!';
 
         $expected = [
@@ -172,13 +168,12 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
             'text' => 'London Olympics: Business Continuity Plan - £100 discount today only!'
         ];
 
-        $this->assertEquals($expected, $factory->decodeHeader($header));
+        $actual = $this->invokeDecodeHeader($header);
+        $this->assertEquals($expected, $actual);
     }
 
     public function testDecodeHeaderMixed()
     {
-        $factory = new Factory();
-
         $header = '=?UTF-8?B?TG9uZG9uIE9seW1waWNzOiBCdXNpbmVzcyBDb250aW4=?='
             . ' =?ISO-8859-1?Q?Keld_J=F8rn_Simonsen?=';
 
@@ -187,20 +182,23 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
             'text' => 'London Olympics: Business ContinKeld Jørn Simonsen'
         ];
 
-        $this->assertEquals($expected, $factory->decodeHeader($header));
+        $actual = $this->invokeDecodeHeader($header);
+        $this->assertEquals($expected, $actual);
     }
 
     public function testDecodeBrokenHeader()
     {
         $header = '=?UTF-8?B?TG9uZG9uIE9seW1waWNzOiBCdXNpbmVzcyBDb250aW4=?=' . "\r\n"
             . ' =?UTF-8?B?dWl0eSBQbGFuIC0gwqPhlibDAgZGlzY291bnQgdG9kYXkgb25seSE=?=';
-        $decoded = (new Factory())->decodeHeader($header);
+        $decoded = $this->invokeDecodeHeader($header);
         $this->assertEquals('UTF-8', $decoded['charset']);
         // test that we can at least show something if the encoded word is malformed (RFC 2047 section 6.3)
         $this->assertStringStartsWith('London Olympics: Business Contin', $decoded['text']);
-
     }
 
+    /**
+     * @deprecated 2.1.0:3.0.0 Method should not have been available in the public interface
+     */
     public function testParseEmailAddresses()
     {
         $factory = new Factory();
@@ -221,6 +219,23 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         ];
 
         $this->assertEquals($expected, $factory->parseEmailAddresses($addresses));
+    }
+
+    /**
+     * Invoke Factory::decodeHeader()
+     *
+     * @see Factory::decodeHeader()
+     * @param string $header
+     * @return array
+     */
+    private function invokeDecodeHeader($header)
+    {
+        $mock = $this->createPartialMock(Factory::class, []);
+
+        $method = new \ReflectionMethod(Factory::class, 'decodeHeader');
+        $method->setAccessible(true);
+
+        return $method->invoke($mock, $header);
     }
 
     /**


### PR DESCRIPTION
These are the deprecations that were in #15 

I think they're still relevant, so can be included in a *minor* release.