### PR TITLE
Extract factory assertions

### DIFF
--- a/tests/AssertAttachmentsEmail.php
+++ b/tests/AssertAttachmentsEmail.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Phlib\Mail\Tests;
+
+use Phlib\Mail\AbstractPart;
+use Phlib\Mail\Content\AbstractContent;
+use Phlib\Mail\Content\Attachment;
+use Phlib\Mail\Content\Content;
+use Phlib\Mail\Content\Html;
+use Phlib\Mail\Content\Text;
+use Phlib\Mail\Mail;
+use Phlib\Mail\Mime\AbstractMime;
+use Phlib\Mail\Mime\MultipartAlternative;
+use Phlib\Mail\Mime\MultipartMixed;
+use Phlib\Mail\Mime\MultipartRelated;
+use PHPUnit\Framework\Assert;
+
+class AssertAttachmentsEmail
+{
+    /**
+     * Assert the Mail object has the expected parts
+     *
+     * @param Mail $mail
+     * @return void
+     */
+    public static function assertEquals(Mail $mail)
+    {
+        // Check headers
+        $expectedHeaders = __DIR__ . '/__files/attachments-expected-headers.txt';
+        Assert::assertEquals(file_get_contents($expectedHeaders), $mail->getEncodedHeaders());
+
+        // Check parts are constructed as expected
+        /** @var MultipartMixed $primaryPart */
+        $primaryPart = $mail->getPart();
+        Assert::assertInstanceOf(MultipartMixed::class, $primaryPart);
+
+        /** @var AbstractMime[] $mixedParts */
+        $mixedParts = $primaryPart->getParts();
+        Assert::assertCount(5, $mixedParts);
+        Assert::assertInstanceOf(MultipartRelated::class, $mixedParts[0]);
+        Assert::assertInstanceOf(Attachment::class, $mixedParts[1]);
+        Assert::assertInstanceOf(Attachment::class, $mixedParts[2]);
+        Assert::assertInstanceOf(Attachment::class, $mixedParts[3]);
+        Assert::assertInstanceOf(Attachment::class, $mixedParts[4]);
+
+        /** @var AbstractPart[] $relatedParts */
+        $relatedParts = $mixedParts[0]->getParts();
+        Assert::assertCount(2, $relatedParts);
+        Assert::assertInstanceOf(MultipartAlternative::class, $relatedParts[0]);
+        Assert::assertInstanceOf(Attachment::class, $relatedParts[1]);
+
+        /** @var AbstractContent[] $alternateParts */
+        $alternateParts = $relatedParts[0]->getParts();
+        Assert::assertCount(2, $alternateParts);
+        Assert::assertInstanceOf(Text::class, $alternateParts[0]);
+        Assert::assertInstanceOf(Html::class, $alternateParts[1]);
+
+        // Check part content
+        $content = [
+            'text' => array(
+                'part' => $alternateParts[0]
+            ),
+            'html' => array(
+                'part' => $alternateParts[1]
+            ),
+            'attch1' => array(
+                'part' => $relatedParts[1],
+                'disposition' => false,
+                'name' => '330.gif',
+                'charset' => false,
+                'type' => 'image/gif'
+            ),
+            'attch2' => array(
+                'part' => $mixedParts[1],
+                'disposition' => true,
+                'name' => 'protocol.txt',
+                'charset' => 'US-ASCII',
+                'type' => 'text/plain'
+            ),
+            'attch3' => array(
+                'part' => $mixedParts[2],
+                'disposition' => true,
+                'name' => 'example-logo.png',
+                'charset' => false,
+                'type' => 'image/png'
+            ),
+            'attch4' => array(
+                'part' => $mixedParts[3],
+                'disposition' => true,
+                'name' => 'Tech_specs-letter_Crucial_m4_ssd_v3-11-11_online.pdf',
+                'charset' => false,
+                'type' => 'application/pdf'
+            ),
+            'attch5' => array(
+                'part' => $mixedParts[4],
+                'disposition' => true,
+                'name' => 'plain.eml',
+                'charset' => 'US-ASCII',
+                'type' => 'text/plain'
+            )
+        ];
+
+        foreach ($content as $name => $details) {
+            /** @var AbstractContent $part */
+            $part = $details['part'];
+
+            // Test part content
+            $expectedContent = __DIR__ . "/__files/attachments-expected-{$name}.txt";
+            $expected = file_get_contents($expectedContent);
+            $actual = $part->encodeContent($part->getContent());
+            Assert::assertEquals($expected, $actual, $name);
+
+            // Test attachments
+            if ($part instanceof Attachment || $part instanceof Content) {
+                $partHeaders = $part->getEncodedHeaders();
+                $contentType = "Content-Type: {$details['type']};";
+                if ($details['charset']) {
+                    $contentType .= " charset=\"{$details['charset']}\";";
+                }
+                $contentType .= " name=\"{$details['name']}\"";
+                Assert::assertContains($contentType, $partHeaders);
+                if ($details['disposition'] === true) {
+                    Assert::assertContains(
+                        'Content-Disposition: attachment; filename="' . $details['name'] . '"',
+                        $partHeaders
+                    );
+                } else {
+                    Assert::assertNotContains('Content-Disposition', $partHeaders);
+                }
+            }
+        }
+    }
+}

--- a/tests/AssertBounceHeadEmail.php
+++ b/tests/AssertBounceHeadEmail.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Phlib\Mail\Tests;
+
+use Phlib\Mail\Content\AbstractContent;
+use Phlib\Mail\Content\Content;
+use Phlib\Mail\Content\Text;
+use Phlib\Mail\Mail;
+use Phlib\Mail\Mime\MultipartReport;
+use PHPUnit\Framework\Assert;
+
+class AssertBounceHeadEmail
+{
+    /**
+     * Assert the Mail object has the expected parts
+     *
+     * @param Mail $mail
+     * @return void
+     */
+    public static function assertEquals(Mail $mail)
+    {
+        // Check headers
+        $expectedHeaders = __DIR__ . '/__files/bounce_head-expected-headers.txt';
+        Assert::assertEquals(file_get_contents($expectedHeaders), $mail->getEncodedHeaders());
+
+        // Check parts are constructed as expected
+        /** @var MultipartReport $primaryPart */
+        $primaryPart = $mail->getPart();
+        Assert::assertInstanceOf(MultipartReport::class, $primaryPart);
+        Assert::assertEquals('multipart/report', $primaryPart->getType());
+        Assert::assertContains('; report-type=delivery-status', $primaryPart->getEncodedHeaders());
+
+        $reportParts = $primaryPart->getParts();
+        Assert::assertCount(3, $reportParts);
+        Assert::assertInstanceOf(Text::class, $reportParts[0]);
+        Assert::assertInstanceOf(Content::class, $reportParts[1]);
+        Assert::assertEquals('message/delivery-status', $reportParts[1]->getType());
+        Assert::assertInstanceOf(Content::class, $reportParts[2]);
+        Assert::assertEquals('text/rfc822-headers', $reportParts[2]->getType());
+
+        // Check part content
+        /** @var AbstractContent[] $content */
+        $content = [
+            'text' => $reportParts[0],
+            'status' => $reportParts[1],
+            'message' => $reportParts[2]
+        ];
+
+        foreach ($content as $name => $part) {
+            $expectedContent = __DIR__ . "/__files/bounce_head-expected-{$name}.txt";
+            $expected = file_get_contents($expectedContent);
+            $actual = $part->encodeContent($part->getContent());
+            Assert::assertEquals($expected, $actual, $name);
+        }
+    }
+}

--- a/tests/AssertBounceMsgEmail.php
+++ b/tests/AssertBounceMsgEmail.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Phlib\Mail\Tests;
+
+use Phlib\Mail\Content\AbstractContent;
+use Phlib\Mail\Content\Content;
+use Phlib\Mail\Content\Html;
+use Phlib\Mail\Content\Text;
+use Phlib\Mail\Mail;
+use Phlib\Mail\Mime\MultipartAlternative;
+use Phlib\Mail\Mime\MultipartReport;
+use PHPUnit\Framework\Assert;
+
+class AssertBounceMsgEmail
+{
+    /**
+     * Assert the Mail object has the expected parts
+     *
+     * @param Mail $mail
+     * @return void
+     */
+    public static function assertEquals(Mail $mail)
+    {
+        // Check headers
+        $expectedHeaders = __DIR__ . '/__files/bounce_msg-expected-headers.txt';
+        Assert::assertEquals(file_get_contents($expectedHeaders), $mail->getEncodedHeaders());
+
+        // Check parts are constructed as expected
+        /** @var MultipartReport $primaryPart */
+        $primaryPart = $mail->getPart();
+        Assert::assertInstanceOf(MultipartReport::class, $primaryPart);
+        Assert::assertEquals('multipart/report', $primaryPart->getType());
+        Assert::assertContains('; report-type=delivery-status', $primaryPart->getEncodedHeaders());
+
+        $reportParts = $primaryPart->getParts();
+        Assert::assertCount(3, $reportParts);
+
+        Assert::assertInstanceOf(MultipartAlternative::class, $reportParts[0]);
+        $alternateParts = $reportParts[0]->getParts();
+        Assert::assertCount(2, $alternateParts);
+        Assert::assertInstanceOf(Text::class, $alternateParts[0]);
+        Assert::assertInstanceOf(Html::class, $alternateParts[1]);
+
+        Assert::assertInstanceOf(Content::class, $reportParts[1]);
+        Assert::assertEquals('message/delivery-status', $reportParts[1]->getType());
+        Assert::assertInstanceOf(Content::class, $reportParts[2]);
+        Assert::assertEquals('message/rfc822', $reportParts[2]->getType());
+
+        // Check part content
+        /** @var AbstractContent[] $content */
+        $content = [
+            'text' => $alternateParts[0],
+            'html' => $alternateParts[1],
+            'status' => $reportParts[1],
+            'message' => $reportParts[2]
+        ];
+
+        foreach ($content as $name => $part) {
+            $expectedContent = __DIR__ . "/__files/bounce_msg-expected-{$name}.txt";
+            $expected = file_get_contents($expectedContent);
+            $actual = $part->encodeContent($part->getContent());
+            Assert::assertEquals($expected, $actual, $name);
+        }
+    }
+}

--- a/tests/AssertContentAttachmentEmail.php
+++ b/tests/AssertContentAttachmentEmail.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Phlib\Mail\Tests;
+
+use Phlib\Mail\Content\Html;
+use Phlib\Mail\Mail;
+use PHPUnit\Framework\Assert;
+
+class AssertContentAttachmentEmail
+{
+    /**
+     * Assert the Mail object has the expected parts
+     *
+     * @param Mail $mail
+     * @return void
+     */
+    public static function assertEquals(Mail $mail)
+    {
+        // Check headers
+        $expectedHeaders = __DIR__ . '/__files/content_attachment-expected-headers.txt';
+        Assert::assertEquals(file_get_contents($expectedHeaders), $mail->getEncodedHeaders());
+
+        // Check parts are constructed as expected
+        /** @var Html $primaryPart */
+        $primaryPart = $mail->getPart();
+        Assert::assertInstanceOf(Html::class, $primaryPart);
+
+        // Check content
+        $expectedContent = __DIR__ . "/__files/content_attachment-expected-html.txt";
+        $expected = file_get_contents($expectedContent);
+        $actual = $primaryPart->encodeContent($primaryPart->getContent());
+        Assert::assertEquals($expected, $actual);
+    }
+}

--- a/tests/AssertHtmlEmail.php
+++ b/tests/AssertHtmlEmail.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Phlib\Mail\Tests;
+
+use Phlib\Mail\Content\Html;
+use Phlib\Mail\Mail;
+use PHPUnit\Framework\Assert;
+
+class AssertHtmlEmail
+{
+    /**
+     * Assert the Mail object has the expected parts
+     *
+     * @param Mail $mail
+     * @return void
+     */
+    public static function assertEquals(Mail $mail)
+    {
+        // Check headers
+        $expectedHeaders = __DIR__ . '/__files/html-expected-headers.txt';
+        Assert::assertEquals(file_get_contents($expectedHeaders), $mail->getEncodedHeaders());
+
+        // Check parts are constructed as expected
+        /** @var Html $primaryPart */
+        $primaryPart = $mail->getPart();
+        Assert::assertInstanceOf(Html::class, $primaryPart);
+
+        // Check content
+        $expectedContent = __DIR__ . "/__files/html-expected-html.txt";
+        $expected = file_get_contents($expectedContent);
+        $actual = $primaryPart->encodeContent($primaryPart->getContent());
+        Assert::assertEquals($expected, $actual);
+    }
+}

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -132,6 +132,44 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertContentAttachmentEmailEquals($mail);
     }
 
+    /**
+     * Tests for an issue (#10) where the Factory was incorrectly handling emails with 9 child parts, as it would
+     * incorrectly try to parse a 10th part (e.g. "1.10") because of non-strict checking for the value "1.10" in the
+     * structure array containing a value "1.1"
+     */
+    public function testNineChildParts()
+    {
+        $source   = __DIR__ . '/__files/mime-9-parts-source.eml';
+
+        $factory = new Factory();
+
+        $mail = $factory->createFromFile($source);
+
+        /** @var AbstractMime $mainPart */
+        $mainPart = $mail->getPart();
+
+        $this->assertEquals(9, count($mainPart->getParts()));
+    }
+
+    public function testGetPartFail()
+    {
+        $warningMsg = 'Couldn\'t get the part';
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage($warningMsg);
+
+        $mailparse_msg_get_part = $this->getFunctionMock('\Phlib\Mail', 'mailparse_msg_get_part');
+        $mailparse_msg_get_part->expects($this->once())
+            ->willReturnCallback(function () use ($warningMsg) {
+                trigger_error($warningMsg, E_USER_WARNING);
+                return false;
+            });
+
+        $source   = __DIR__ . '/__files/bounce_msg-source.eml';
+
+        (new Factory())->createFromFile($source);
+    }
+
     public function testDecodeHeaderUtf8Base64()
     {
         $factory = new Factory();
@@ -221,44 +259,6 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         ];
 
         $this->assertEquals($expected, $factory->parseEmailAddresses($addresses));
-    }
-
-    /**
-     * Tests for an issue (#10) where the Factory was incorrectly handling emails with 9 child parts, as it would
-     * incorrectly try to parse a 10th part (e.g. "1.10") because of non-strict checking for the value "1.10" in the
-     * structure array containing a value "1.1"
-     */
-    public function testNineChildParts()
-    {
-        $source   = __DIR__ . '/__files/mime-9-parts-source.eml';
-
-        $factory = new Factory();
-
-        $mail = $factory->createFromFile($source);
-
-        /** @var AbstractMime $mainPart */
-        $mainPart = $mail->getPart();
-
-        $this->assertEquals(9, count($mainPart->getParts()));
-    }
-
-    public function testGetPartFail()
-    {
-        $warningMsg = 'Couldn\'t get the part';
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage($warningMsg);
-
-        $mailparse_msg_get_part = $this->getFunctionMock('\Phlib\Mail', 'mailparse_msg_get_part');
-        $mailparse_msg_get_part->expects($this->once())
-            ->willReturnCallback(function () use ($warningMsg) {
-                trigger_error($warningMsg, E_USER_WARNING);
-                return false;
-            });
-
-        $source   = __DIR__ . '/__files/bounce_msg-source.eml';
-
-        (new Factory())->createFromFile($source);
     }
 
     protected function assertAttachmentsEmailEquals(\Phlib\Mail\Mail $mail)

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -40,7 +40,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $factory = new Factory();
         $mail = $factory->createFromFile($source);
 
-        $this->assertAttachmentsEmailEquals($mail);
+        AssertAttachmentsEmail::assertEquals($mail);
         $this->assertEquals(true, $mail->hasAttachment());
         $this->assertEquals(5, $mail->getAttachmentCount());
     }
@@ -59,7 +59,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $factory = new Factory();
         $mail = $factory->createFromString(file_get_contents($source));
 
-        $this->assertAttachmentsEmailEquals($mail);
+        AssertAttachmentsEmail::assertEquals($mail);
         $this->assertEquals(true, $mail->hasAttachment());
         $this->assertEquals(5, $mail->getAttachmentCount());
     }
@@ -78,7 +78,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $factory = new Factory();
         $mail = $factory->createFromFile($source);
 
-        $this->assertBounceHeadEmailEquals($mail);
+        AssertBounceHeadEmail::assertEquals($mail);
         $this->assertEquals(true, $mail->hasAttachment());
         $this->assertEquals(2, $mail->getAttachmentCount());
     }
@@ -97,7 +97,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $factory = new Factory();
         $mail = $factory->createFromFile($source);
 
-        $this->assertBounceMsgEmailEquals($mail);
+        AssertBounceMsgEmail::assertEquals($mail);
     }
 
     /**
@@ -113,7 +113,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $factory = new Factory();
         $mail = $factory->createFromFile($source);
 
-        $this->assertHtmlEmailEquals($mail);
+        AssertHtmlEmail::assertEquals($mail);
     }
 
     /**
@@ -129,7 +129,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $factory = new Factory();
         $mail = $factory->createFromFile($source);
 
-        $this->assertContentAttachmentEmailEquals($mail);
+        AssertContentAttachmentEmail::assertEquals($mail);
     }
 
     /**
@@ -259,230 +259,5 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         ];
 
         $this->assertEquals($expected, $factory->parseEmailAddresses($addresses));
-    }
-
-    protected function assertAttachmentsEmailEquals(\Phlib\Mail\Mail $mail)
-    {
-        // Check headers
-        $expectedHeaders = __DIR__ . '/__files/attachments-expected-headers.txt';
-        $this->assertEquals(file_get_contents($expectedHeaders), $mail->getEncodedHeaders());
-
-        // Check parts are constructed as expected
-        /** @var \Phlib\Mail\Mime\MultipartMixed $primaryPart */
-        $primaryPart = $mail->getPart();
-        $this->assertInstanceOf(MultipartMixed::class, $primaryPart);
-
-        /** @var \Phlib\Mail\Mime\AbstractMime[] $mixedParts */
-        $mixedParts = $primaryPart->getParts();
-        $this->assertCount(5, $mixedParts);
-        $this->assertInstanceOf(MultipartRelated::class, $mixedParts[0]);
-        $this->assertInstanceOf(Attachment::class, $mixedParts[1]);
-        $this->assertInstanceOf(Attachment::class, $mixedParts[2]);
-        $this->assertInstanceOf(Attachment::class, $mixedParts[3]);
-        $this->assertInstanceOf(Attachment::class, $mixedParts[4]);
-
-        /** @var \Phlib\Mail\AbstractPart[] $relatedParts */
-        $relatedParts = $mixedParts[0]->getParts();
-        $this->assertCount(2, $relatedParts);
-        $this->assertInstanceOf(MultipartAlternative::class, $relatedParts[0]);
-        $this->assertInstanceOf(Attachment::class, $relatedParts[1]);
-
-        /** @var \Phlib\Mail\Content\AbstractContent[] $alternateParts */
-        $alternateParts = $relatedParts[0]->getParts();
-        $this->assertCount(2, $alternateParts);
-        $this->assertInstanceOf(Text::class, $alternateParts[0]);
-        $this->assertInstanceOf(Html::class, $alternateParts[1]);
-
-        // Check part content
-        $content = [
-            'text' => array(
-                'part' => $alternateParts[0]
-            ),
-            'html' => array(
-                'part' => $alternateParts[1]
-            ),
-            'attch1' => array(
-                'part' => $relatedParts[1],
-                'disposition' => false,
-                'name' => '330.gif',
-                'charset' => false,
-                'type' => 'image/gif'
-            ),
-            'attch2' => array(
-                'part' => $mixedParts[1],
-                'disposition' => true,
-                'name' => 'protocol.txt',
-                'charset' => 'US-ASCII',
-                'type' => 'text/plain'
-            ),
-            'attch3' => array(
-                'part' => $mixedParts[2],
-                'disposition' => true,
-                'name' => 'example-logo.png',
-                'charset' => false,
-                'type' => 'image/png'
-            ),
-            'attch4' => array(
-                'part' => $mixedParts[3],
-                'disposition' => true,
-                'name' => 'Tech_specs-letter_Crucial_m4_ssd_v3-11-11_online.pdf',
-                'charset' => false,
-                'type' => 'application/pdf'
-            ),
-            'attch5' => array(
-                'part' => $mixedParts[4],
-                'disposition' => true,
-                'name' => 'plain.eml',
-                'charset' => 'US-ASCII',
-                'type' => 'text/plain'
-            )
-        ];
-
-        foreach ($content as $name => $details) {
-            /** @var \Phlib\Mail\Content\AbstractContent $part */
-            $part = $details['part'];
-
-            // Test part content
-            $expectedContent = __DIR__ . "/__files/attachments-expected-{$name}.txt";
-            $expected = file_get_contents($expectedContent);
-            $actual = $part->encodeContent($part->getContent());
-            $this->assertEquals($expected, $actual, $name);
-
-            // Test attachments
-            if ($part instanceof Attachment || $part instanceof Content) {
-                $partHeaders = $part->getEncodedHeaders();
-                $contentType = "Content-Type: {$details['type']};";
-                if ($details['charset']) {
-                    $contentType .= " charset=\"{$details['charset']}\";";
-                }
-                $contentType .= " name=\"{$details['name']}\"";
-                $this->assertContains($contentType, $partHeaders);
-                if ($details['disposition'] === true) {
-                    $this->assertContains(
-                        'Content-Disposition: attachment; filename="' . $details['name'] . '"',
-                        $partHeaders
-                    );
-                } else {
-                    $this->assertNotContains('Content-Disposition', $partHeaders);
-                }
-            }
-        }
-    }
-
-    protected function assertBounceHeadEmailEquals(\Phlib\Mail\Mail $mail)
-    {
-        // Check headers
-        $expectedHeaders = __DIR__ . '/__files/bounce_head-expected-headers.txt';
-        $this->assertEquals(file_get_contents($expectedHeaders), $mail->getEncodedHeaders());
-
-        // Check parts are constructed as expected
-        /** @var \Phlib\Mail\Mime\Mime $primaryPart */
-        $primaryPart = $mail->getPart();
-        $this->assertInstanceOf(MultipartReport::class, $primaryPart);
-        $this->assertEquals('multipart/report', $primaryPart->getType());
-        $this->assertContains('; report-type=delivery-status', $primaryPart->getEncodedHeaders());
-
-        $reportParts = $primaryPart->getParts();
-        $this->assertCount(3, $reportParts);
-        $this->assertInstanceOf(Text::class, $reportParts[0]);
-        $this->assertInstanceOf(Content::class, $reportParts[1]);
-        $this->assertEquals('message/delivery-status', $reportParts[1]->getType());
-        $this->assertInstanceOf(Content::class, $reportParts[2]);
-        $this->assertEquals('text/rfc822-headers', $reportParts[2]->getType());
-
-        // Check part content
-        /** @var \Phlib\Mail\Content\AbstractContent[] $content */
-        $content = [
-            'text' => $reportParts[0],
-            'status' => $reportParts[1],
-            'message' => $reportParts[2]
-        ];
-
-        foreach ($content as $name => $part) {
-            $expectedContent = __DIR__ . "/__files/bounce_head-expected-{$name}.txt";
-            $expected = file_get_contents($expectedContent);
-            $actual = $part->encodeContent($part->getContent());
-            $this->assertEquals($expected, $actual, $name);
-        }
-    }
-
-    protected function assertBounceMsgEmailEquals(\Phlib\Mail\Mail $mail)
-    {
-        // Check headers
-        $expectedHeaders = __DIR__ . '/__files/bounce_msg-expected-headers.txt';
-        $this->assertEquals(file_get_contents($expectedHeaders), $mail->getEncodedHeaders());
-
-        // Check parts are constructed as expected
-        /** @var \Phlib\Mail\Mime\Mime $primaryPart */
-        $primaryPart = $mail->getPart();
-        $this->assertInstanceOf(MultipartReport::class, $primaryPart);
-        $this->assertEquals('multipart/report', $primaryPart->getType());
-        $this->assertContains('; report-type=delivery-status', $primaryPart->getEncodedHeaders());
-
-        $reportParts = $primaryPart->getParts();
-        $this->assertCount(3, $reportParts);
-
-        $this->assertInstanceOf(MultipartAlternative::class, $reportParts[0]);
-        $alternateParts = $reportParts[0]->getParts();
-        $this->assertCount(2, $alternateParts);
-        $this->assertInstanceOf(Text::class, $alternateParts[0]);
-        $this->assertInstanceOf(Html::class, $alternateParts[1]);
-
-        $this->assertInstanceOf(Content::class, $reportParts[1]);
-        $this->assertEquals('message/delivery-status', $reportParts[1]->getType());
-        $this->assertInstanceOf(Content::class, $reportParts[2]);
-        $this->assertEquals('message/rfc822', $reportParts[2]->getType());
-
-        // Check part content
-        /** @var \Phlib\Mail\Content\AbstractContent[] $content */
-        $content = [
-            'text' => $alternateParts[0],
-            'html' => $alternateParts[1],
-            'status' => $reportParts[1],
-            'message' => $reportParts[2]
-        ];
-
-        foreach ($content as $name => $part) {
-            $expectedContent = __DIR__ . "/__files/bounce_msg-expected-{$name}.txt";
-            $expected = file_get_contents($expectedContent);
-            $actual = $part->encodeContent($part->getContent());
-            $this->assertEquals($expected, $actual, $name);
-        }
-    }
-
-    protected function assertHtmlEmailEquals(\Phlib\Mail\Mail $mail)
-    {
-        // Check headers
-        $expectedHeaders = __DIR__ . '/__files/html-expected-headers.txt';
-        $this->assertEquals(file_get_contents($expectedHeaders), $mail->getEncodedHeaders());
-
-        // Check parts are constructed as expected
-        /** @var \Phlib\Mail\Mime\MultipartMixed $primaryPart */
-        $primaryPart = $mail->getPart();
-        $this->assertInstanceOf(Html::class, $primaryPart);
-
-        // Check content
-        $expectedContent = __DIR__ . "/__files/html-expected-html.txt";
-        $expected = file_get_contents($expectedContent);
-        $actual = $primaryPart->encodeContent($primaryPart->getContent());
-        $this->assertEquals($expected, $actual);
-    }
-
-    protected function assertContentAttachmentEmailEquals(\Phlib\Mail\Mail $mail)
-    {
-        // Check headers
-        $expectedHeaders = __DIR__ . '/__files/content_attachment-expected-headers.txt';
-        $this->assertEquals(file_get_contents($expectedHeaders), $mail->getEncodedHeaders());
-
-        // Check parts are constructed as expected
-        /** @var \Phlib\Mail\Content\Html $primaryPart */
-        $primaryPart = $mail->getPart();
-        $this->assertInstanceOf(Html::class, $primaryPart);
-
-        // Check content
-        $expectedContent = __DIR__ . "/__files/content_attachment-expected-html.txt";
-        $expected = file_get_contents($expectedContent);
-        $actual = $primaryPart->encodeContent($primaryPart->getContent());
-        $this->assertEquals($expected, $actual);
     }
 }


### PR DESCRIPTION
This is a change which was in #15 

Clean out the massive collection of assertions from `FactoryTest` to make that a little more reasonably sized.