### PR TITLE
Free Mailparse resources (v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Free internal Mailparse resources once the email has been parsed. This should
+help PHP to free up memory.
 ### Changed
 - Clarify the return type for the following `Mail` methods to show they can be
 null if not set: `getFrom()`, `getReplyTo()`, `getReturnPath()`, `getSubject()`

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -10,22 +10,22 @@ class Factory
     /**
      * @var bool
      */
-    private $isFile = false;
+    private $isFile;
 
     /**
      * @var string
      */
-    private $source = '';
+    private $source;
 
     /**
      * @var resource
      */
-    private $mimeMail = null;
+    private $mimeMail;
 
     /**
      * @var array
      */
-    private $structure = array();
+    private $structure;
 
     /**
      * Load email from file
@@ -55,9 +55,10 @@ class Factory
                 mailparse_msg_free($this->mimeMail);
             }
             unset(
-                $this->mimeMail,
+                $this->isFile,
                 $this->source,
-                $this->isFile
+                $this->mimeMail,
+                $this->structure
             );
         }
     }
@@ -98,9 +99,10 @@ class Factory
                 mailparse_msg_free($this->mimeMail);
             }
             unset(
-                $this->mimeMail,
+                $this->isFile,
                 $this->source,
-                $this->isFile
+                $this->mimeMail,
+                $this->structure
             );
         }
     }


### PR DESCRIPTION
Following on from #15 this PR only has changes to free the resources once they're finished being used.

Tests are updated to make sure that the resource is freed in the `finally` when the `Mail` object is returned.

This should be the last feature for v2.1.0