### PR TITLE
Trailing newline issue

### DIFF
--- a/src/Mail.php
+++ b/src/Mail.php
@@ -449,6 +449,18 @@ class Mail extends AbstractPart
      */
     public function toString()
     {
-        return $this->getEncodedHeaders() . $this->getPart()->toString();
+        $result = $this->getEncodedHeaders() . $this->getPart()->toString();
+        if (substr($result, -1) !== "\n") {
+            // If mail doesn't end with a newline, then append one
+            //
+            // This is mostly to get around an issue when parsing the mail string back in through the Factory, as mailparse
+            // cuts off the last line of the email body if it doesn't end with a newline (https://bugs.php.net/bug.php?id=75923)
+            //
+            // A known issue with this, however, is that a mail with only a content part which is successively
+            // parsed->output->parsed->output will keep gaining new lines each time
+            // (unless the content is base64 encoded, as raw whitespace is discarded when decoding)
+            $result .= "\r\n";
+        }
+        return $result;
     }
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Phlib\Mail\Tests;
+
+use Phlib\Mail\AbstractPart;
+use Phlib\Mail\Content\AbstractContent;
+use Phlib\Mail\Content\Html;
+use Phlib\Mail\Content\Text;
+use Phlib\Mail\Factory;
+use Phlib\Mail\Mime\AbstractMime;
+use Phlib\Mail\Mime\MultipartAlternative;
+
+class IntegrationTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testRecreateMultipartMail()
+    {
+        $originalMail = new \Phlib\Mail\Mail();
+        $originalMail->addTo('to@example.com');
+        $originalMail->setFrom('from@example.com');
+        $originalMail->setSubject('Subject line');
+        $contentPart = new MultipartAlternative();
+        $contentPart->addPart((new Html())
+            ->setContent('Test <b>html</b>')
+            ->setEncoding(AbstractPart::ENCODING_BASE64));
+        $contentPart->addPart((new Text())
+            ->setContent('Test text')
+            ->setEncoding(AbstractPart::ENCODING_BASE64));
+        $originalMail->setPart($contentPart);
+
+        $source = $originalMail->toString();
+
+        $mail = (new Factory())->createFromString($source);
+
+        /** @var AbstractMime $mainPart */
+        $mainPart = $mail->getPart();
+        $this->assertInstanceOf(AbstractMime::class, $mainPart);
+        $parts    = $mainPart->getParts();
+        $this->assertCount(2, $parts);
+        /** @var AbstractContent $htmlPart */
+        /** @var AbstractContent $textPart */
+        list($htmlPart, $textPart) = $parts;
+
+        $this->assertEquals('Test <b>html</b>', $htmlPart->getContent());
+        $this->assertEquals('Test text', $textPart->getContent());
+    }
+
+    public function testRecreateContentOnlyMail()
+    {
+        $originalMail = new \Phlib\Mail\Mail();
+        $originalMail->addTo('to@example.com');
+        $originalMail->setFrom('from@example.com');
+        $originalMail->setSubject('Subject line');
+        $contentPart = (new Text())
+            ->setContent('Test text')
+            ->setEncoding(AbstractPart::ENCODING_BASE64);
+        $originalMail->setPart($contentPart);
+
+        $source = $originalMail->toString();
+
+        $mail = (new Factory())->createFromString($source);
+
+        /** @var AbstractContent $mainPart */
+        $mainPart = $mail->getPart();
+        $this->assertInstanceOf(AbstractContent::class, $mainPart);
+
+        $this->assertEquals('Test text', $mainPart->getContent());
+    }
+}

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -297,7 +297,7 @@ class MailTest extends \PHPUnit_Framework_TestCase
         list($actualHeaders, $actualContent) = explode("\r\n\r\n", $actual, 2);
 
         $this->assertEquals($expectedHeaders, iconv_mime_decode_headers($actualHeaders));
-        $this->assertEquals($content, $actualContent);
+        $this->assertEquals($content, trim($actualContent));
     }
 
     /**


### PR DESCRIPTION
This is an unfortunate workaround for https://bugs.php.net/bug.php?id=75923.

This only solves the issue in terms of reading back a mail string which has been output by a phlib mail object.

An alternative would have been to add a trailing newline to the end of the mail string when it gets passed into the factory so that it would work for all emails, but we would only be able to do this when creating from string (not when creating from file), so would be a big inconsistency.