### PR TITLE
Remove support for PHP 5.x and 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,12 @@
 language: php
 
-matrix:
-  include:
-    - php: 5.6
-      env: EXT_MAILPARSE_VER="-f mailparse-2.1.6"
-    - php: 7.0
-      env: EXT_MAILPARSE_VER="mailparse"
-    - php: 7.1
-      env: EXT_MAILPARSE_VER="mailparse"
+php:
+- 7.1
+- 7.2
 
 before_script:
   - pecl channel-update pecl.php.net
-  - pecl install $EXT_MAILPARSE_VER
+  - pecl install mailparse
   - composer self-update
   - composer install --no-interaction
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Removed
+- Removed support for PHP 5.x and 7.0 as they are no longer
+[actively supported](https://php.net/supported-versions.php) by the PHP project
 
 ## [2.1.1] - 2018-03-19
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- PHP 7.1 scalar type declarations and return types
 ### Removed
 - Removed support for PHP 5.x and 7.0 as they are no longer
 [actively supported](https://php.net/supported-versions.php) by the PHP project

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
     },
     "require-dev": {
         "ext-iconv" : "*",
-        "phpunit/phpunit": "^5.7",
-        "php-mock/php-mock-phpunit": "^1.1"
+        "phpunit/phpunit": "^7",
+        "php-mock/php-mock-phpunit": "^2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "php": "^5.6|^7.0",
+        "php": "^7.1",
         "ext-mailparse" : "*",
         "ext-mbstring": "*"
     },

--- a/src/AbstractPart.php
+++ b/src/AbstractPart.php
@@ -15,7 +15,7 @@ abstract class AbstractPart
     /**
      * @var array
      */
-    private $headers = array();
+    private $headers = [];
 
     /**
      * @var array
@@ -76,7 +76,7 @@ abstract class AbstractPart
         $filteredValue = strtr($value, $rule);
 
         if (!array_key_exists($name, $this->headers)) {
-            $this->headers[$name] = array();
+            $this->headers[$name] = [];
         }
         $this->headers[$name][] = $filteredValue;
 
@@ -93,7 +93,7 @@ abstract class AbstractPart
 
     public function clearHeaders(): self
     {
-        $this->headers = array();
+        $this->headers = [];
         return $this;
     }
 
@@ -146,7 +146,7 @@ abstract class AbstractPart
 
     public function getEncodedHeaders(): string
     {
-        $headers = array();
+        $headers = [];
 
         foreach ($this->headers as $name => $values) {
             foreach ($values as $value) {

--- a/src/AbstractPart.php
+++ b/src/AbstractPart.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail;
 

--- a/src/AbstractPart.php
+++ b/src/AbstractPart.php
@@ -56,10 +56,10 @@ abstract class AbstractPart
      *
      * @param string $name
      * @param string $value
-     * @return AbstractPart
+     * @return $this
      * @throws InvalidArgumentException
      */
-    public function addHeader($name, $value)
+    public function addHeader(string $name, string $value): self
     {
         $name = strtolower($name);
         if (in_array($name, $this->prohibitedHeaders)) {
@@ -83,14 +83,7 @@ abstract class AbstractPart
         return $this;
     }
 
-    /**
-     * Set header
-     *
-     * @param string $name
-     * @param string $value
-     * @return AbstractPart
-     */
-    public function setHeader($name, $value)
+    public function setHeader(string $name, string $value): self
     {
         $this->clearHeader($name);
         $this->addHeader($name, $value);
@@ -98,24 +91,13 @@ abstract class AbstractPart
         return $this;
     }
 
-    /**
-     * Clear headers
-     *
-     * @return AbstractPart
-     */
-    public function clearHeaders()
+    public function clearHeaders(): self
     {
         $this->headers = array();
         return $this;
     }
 
-    /**
-     * Clear header
-     *
-     * @param string $name
-     * @return AbstractPart
-     */
-    public function clearHeader($name)
+    public function clearHeader(string $name): self
     {
         $name = strtolower($name);
         unset($this->headers[$name]);
@@ -123,14 +105,7 @@ abstract class AbstractPart
         return $this;
     }
 
-    /**
-     * Remove header
-     *
-     * @param string $name
-     * @param string $value
-     * @return AbstractPart
-     */
-    public function removeHeader($name, $value)
+    public function removeHeader(string $name, string $value): self
     {
         $name = strtolower($name);
         if (array_key_exists($name, $this->headers)) {
@@ -145,23 +120,12 @@ abstract class AbstractPart
         return $this;
     }
 
-    /**
-     * Get headers
-     *
-     * @return array
-     */
-    public function getHeaders()
+    public function getHeaders(): array
     {
         return $this->headers;
     }
 
-    /**
-     * Get header
-     *
-     * @param string $name
-     * @return array
-     */
-    public function getHeader($name)
+    public function getHeader(string $name): array
     {
         $name = strtolower($name);
         if (!array_key_exists($name, $this->headers)) {
@@ -170,13 +134,7 @@ abstract class AbstractPart
         return $this->headers[$name];
     }
 
-    /**
-     * Has header
-     *
-     * @param string $name
-     * @return boolean
-     */
-    public function hasHeader($name)
+    public function hasHeader(string $name): bool
     {
         $name = strtolower($name);
         if (isset($this->headers[$name]) && !empty($this->headers[$name])) {
@@ -186,12 +144,7 @@ abstract class AbstractPart
         return false;
     }
 
-    /**
-     * Get encoded headers
-     *
-     * @return string
-     */
-    public function getEncodedHeaders()
+    public function getEncodedHeaders(): string
     {
         $headers = array();
 
@@ -230,39 +183,23 @@ abstract class AbstractPart
      * @param string $contentType
      * @return string
      */
-    protected function addContentTypeParameters($contentType)
+    protected function addContentTypeParameters(string $contentType): string
     {
         return $contentType;
     }
 
-    /**
-     * Set charset
-     *
-     * @param string $charset
-     * @return AbstractPart
-     */
-    public function setCharset($charset)
+    public function setCharset(string $charset): self
     {
         $this->charset = $charset;
         return $this;
     }
 
-    /**
-     * Get charset
-     *
-     * @return string
-     */
-    public function getCharset()
+    public function getCharset(): ?string
     {
         return $this->charset;
     }
 
-    /**
-     * Get encoding
-     *
-     * @return string
-     */
-    public function getEncoding()
+    public function getEncoding(): string
     {
         return $this->encoding;
     }
@@ -271,10 +208,10 @@ abstract class AbstractPart
      * Set encoding
      *
      * @param string $encoding
-     * @return AbstractPart
+     * @return $this
      * @throws InvalidArgumentException
      */
-    public function setEncoding($encoding)
+    public function setEncoding(string $encoding): self
     {
         $encoding = strtolower($encoding);
         if (!in_array($encoding, $this->validEncodings)) {
@@ -285,23 +222,12 @@ abstract class AbstractPart
         return $this;
     }
 
-    /**
-     * Get type
-     *
-     * @return string
-     */
-    public function getType()
+    public function getType(): ?string
     {
         return $this->type;
     }
 
-    /**
-     * Encode header
-     *
-     * @param string $header
-     * @return string
-     */
-    public function encodeHeader($header)
+    public function encodeHeader(string $header): string
     {
         $charset = $this->charset;
         if (!$charset) {
@@ -310,10 +236,5 @@ abstract class AbstractPart
         return mb_encode_mimeheader($header, $charset);
     }
 
-    /**
-     * To string
-     *
-     * @return string
-     */
-    abstract public function toString();
+    abstract public function toString(): string;
 }

--- a/src/Content/AbstractContent.php
+++ b/src/Content/AbstractContent.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Content;
 

--- a/src/Content/AbstractContent.php
+++ b/src/Content/AbstractContent.php
@@ -12,35 +12,18 @@ abstract class AbstractContent extends AbstractPart
      */
     private $content = '';
 
-    /**
-     * Set content
-     *
-     * @param string $content
-     * @return AbstractContent
-     */
-    public function setContent($content)
+    public function setContent(string $content): self
     {
         $this->content = $content;
         return $this;
     }
 
-    /**
-     * Get content
-     *
-     * @return string
-     */
-    public function getContent()
+    public function getContent(): string
     {
         return $this->content;
     }
 
-    /**
-     * Encode content
-     *
-     * @param string $content
-     * @return string
-     */
-    public function encodeContent($content)
+    public function encodeContent(string $content): string
     {
         switch ($this->encoding) {
             case self::ENCODING_QPRINTABLE:
@@ -59,12 +42,7 @@ abstract class AbstractContent extends AbstractPart
         }
     }
 
-    /**
-     * To string
-     *
-     * @return string
-     */
-    public function toString()
+    public function toString(): string
     {
         return $this->getEncodedHeaders() . "\r\n" . $this->encodeContent($this->getContent());
     }

--- a/src/Content/Attachment.php
+++ b/src/Content/Attachment.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Content;
 

--- a/src/Content/Attachment.php
+++ b/src/Content/Attachment.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Phlib\Mail\Content;
 
+use Phlib\Mail\AbstractPart;
 use Phlib\Mail\Exception\InvalidArgumentException;
 
 /**
@@ -32,9 +33,9 @@ class Attachment extends AbstractContent
      *
      * @param string $filename
      * @param string $disposition Optional disposition, eg. 'attachment'. NULL to ignore.
-     * @return Attachment
+     * @return $this
      */
-    public static function createFromFile($filename, $disposition = null)
+    public static function createFromFile(string $filename, ?string $disposition = null): Attachment
     {
         if (!is_readable($filename)) {
             throw new InvalidArgumentException('Attachment file cannot be read');
@@ -53,7 +54,7 @@ class Attachment extends AbstractContent
      * @param string $disposition Optional disposition, eg. 'attachment'. NULL to ignore.
      * @param string $type
      */
-    public function __construct($name, $disposition = null, $type = 'application/octet-stream')
+    public function __construct(string $name, ?string $disposition = null, string $type = 'application/octet-stream')
     {
         $this->name = $name;
         $this->disposition = $disposition;
@@ -67,10 +68,10 @@ class Attachment extends AbstractContent
      * Set encoding
      *
      * @param string $encoding
-     * @return Attachment
+     * @return $this
      * @throws InvalidArgumentException
      */
-    public function setEncoding($encoding)
+    public function setEncoding(string $encoding): AbstractPart
     {
         if ($encoding !== 'base64') {
             throw new InvalidArgumentException('Will only accept base64 for attachment encoding');
@@ -79,12 +80,7 @@ class Attachment extends AbstractContent
         return $this;
     }
 
-    /**
-     * Get encoded headers
-     *
-     * @return string
-     */
-    public function getEncodedHeaders()
+    public function getEncodedHeaders(): string
     {
         $headers = parent::getEncodedHeaders();
         if ($this->disposition) {
@@ -101,7 +97,7 @@ class Attachment extends AbstractContent
      * @param string $contentType
      * @return string
      */
-    protected function addContentTypeParameters($contentType)
+    protected function addContentTypeParameters(string $contentType): string
     {
         $contentType .= "; name=\"{$this->name}\"";
 

--- a/src/Content/Content.php
+++ b/src/Content/Content.php
@@ -10,7 +10,7 @@ class Content extends AbstractContent
      *
      * @param string $type
      */
-    public function __construct($type = 'application/octet-stream')
+    public function __construct(string $type = 'application/octet-stream')
     {
         $this->type = $type;
     }

--- a/src/Content/Content.php
+++ b/src/Content/Content.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Content;
 

--- a/src/Content/Html.php
+++ b/src/Content/Html.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Content;
 

--- a/src/Content/Text.php
+++ b/src/Content/Text.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Content;
 

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Exception;
 

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Exception;
 

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Exception;
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail;
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -35,7 +35,7 @@ class Factory
      * @return Mail
      * @throws RuntimeException
      */
-    public function createFromFile($filename)
+    public function createFromFile(string $filename): Mail
     {
         try {
             $this->source = $filename;
@@ -69,7 +69,7 @@ class Factory
      * @param string $filename
      * @return Mail
      */
-    public static function fromFile($filename)
+    public static function fromFile(string $filename): Mail
     {
         return (new self)->createFromFile($filename);
     }
@@ -81,7 +81,7 @@ class Factory
      * @return Mail
      * @throws RuntimeException
      */
-    public function createFromString($source)
+    public function createFromString(string $source): Mail
     {
         try {
             $this->source = $source;
@@ -113,7 +113,7 @@ class Factory
      * @param string $source
      * @return Mail
      */
-    public static function fromString($source)
+    public static function fromString(string $source): Mail
     {
         return (new self)->createFromString($source);
     }
@@ -124,7 +124,7 @@ class Factory
      * @return Mail
      * @throws RuntimeException
      */
-    private function parseEmail()
+    private function parseEmail(): Mail
     {
         $mail = new Mail();
 
@@ -149,14 +149,7 @@ class Factory
         return $mail;
     }
 
-    /**
-     * Add headers to the Mail object
-     *
-     * @param Mail $mail
-     * @param array $headers
-     * @return void
-     */
-    private function addMailHeaders(Mail $mail, array $headers)
+    private function addMailHeaders(Mail $mail, array $headers): void
     {
         $charset = null;
 
@@ -215,14 +208,7 @@ class Factory
         }
     }
 
-    /**
-     * Add headers to a mail part
-     *
-     * @param AbstractPart $part
-     * @param array $headers
-     * @return void
-     */
-    private function addHeaders(AbstractPart $part, array $headers)
+    private function addHeaders(AbstractPart $part, array $headers): void
     {
         $charset = null;
         if (method_exists($part, 'getCharset')) {
@@ -252,7 +238,7 @@ class Factory
      * @param Mail $mail
      * @return AbstractPart
      */
-    private function parsePart($name, Mail $mail)
+    private function parsePart(string $name, Mail $mail): AbstractPart
     {
         // Get part resource
         if (($part     = @mailparse_msg_get_part($this->mimeMail, $name)) === false ||
@@ -364,7 +350,7 @@ class Factory
      * }
      * @throws InvalidArgumentException
      */
-    public function decodeHeader($header, $charset = null)
+    public function decodeHeader(string $header, ?string $charset = null): array
     {
         if (preg_match('/=\?([^\?]+)\?([^\?])\?[^\?]+\?=/', $header, $matches) > 0) {
             if ($charset === null) {
@@ -394,7 +380,7 @@ class Factory
      * @return array 'display', 'address' and 'is_group'
      * @see mailparse_rfc822_parse_addresses
      */
-    public function parseEmailAddresses($addresses)
+    public function parseEmailAddresses(string $addresses): array
     {
         return mailparse_rfc822_parse_addresses($addresses);
     }

--- a/src/Mail.php
+++ b/src/Mail.php
@@ -68,13 +68,7 @@ class Mail extends AbstractPart
      */
     private $attachmentCount = 0;
 
-    /**
-     * Set part
-     *
-     * @param AbstractPart $part
-     * @return $this
-     */
-    public function setPart(AbstractPart $part)
+    public function setPart(AbstractPart $part): self
     {
         $this->part = $part;
         return $this;
@@ -86,7 +80,7 @@ class Mail extends AbstractPart
      * @return AbstractPart
      * @throws RuntimeException
      */
-    public function getPart()
+    public function getPart(): AbstractPart
     {
         if (!$this->part) {
             throw new RuntimeException('Missing mail part');
@@ -94,12 +88,7 @@ class Mail extends AbstractPart
         return $this->part;
     }
 
-    /**
-     * Get encoded headers
-     *
-     * @return string
-     */
-    public function getEncodedHeaders()
+    public function getEncodedHeaders(): string
     {
         $headers = array();
 
@@ -157,7 +146,7 @@ class Mail extends AbstractPart
      * @return $this
      * @throws InvalidArgumentException
      */
-    public function addTo($address, $name = null)
+    public function addTo(string $address, ?string $name = null): self
     {
         if (filter_var($address, FILTER_VALIDATE_EMAIL) === false) {
             throw new InvalidArgumentException("Invalid email address ($address)");
@@ -170,36 +159,19 @@ class Mail extends AbstractPart
         return $this;
     }
 
-    /**
-     * Get to
-     *
-     * @return array
-     */
-    public function getTo()
+    public function getTo(): array
     {
         return $this->to;
     }
 
-    /**
-     * Clear any to addresses
-     *
-     * @return $this
-     */
-    public function clearTo()
+    public function clearTo(): self
     {
         $this->to = array();
 
         return $this;
     }
 
-    /**
-     * Add CC
-     *
-     * @param string $address
-     * @param string $name
-     * @return $this
-     */
-    public function addCc($address, $name = null)
+    public function addCc(string $address, ?string $name = null): self
     {
         if (filter_var($address, FILTER_VALIDATE_EMAIL) === false) {
             throw new InvalidArgumentException("Invalid email address ($address)");
@@ -212,22 +184,12 @@ class Mail extends AbstractPart
         return $this;
     }
 
-    /**
-     * Get cc
-     *
-     * @return array
-     */
-    public function getCc()
+    public function getCc(): array
     {
         return $this->cc;
     }
 
-    /**
-     * Clear cc addresses
-     *
-     * @return $this
-     */
-    public function clearCc()
+    public function clearCc(): self
     {
         $this->cc = array();
 
@@ -242,7 +204,7 @@ class Mail extends AbstractPart
      * @return $this
      * @throws InvalidArgumentException
      */
-    public function setReplyTo($address, $name = null)
+    public function setReplyTo(string $address, ?string $name = null): self
     {
         if (filter_var($address, FILTER_VALIDATE_EMAIL) === false) {
             throw new InvalidArgumentException("Invalid email address ($address)");
@@ -257,23 +219,12 @@ class Mail extends AbstractPart
         return $this;
     }
 
-    /**
-     * Get reply to
-     *
-     * @return array|null
-     */
-    public function getReplyTo()
+    public function getReplyTo(): ?array
     {
         return $this->replyTo;
     }
 
-    /**
-     * Filter name
-     *
-     * @param string $name
-     * @return string
-     */
-    private function filterName($name)
+    private function filterName(string $name): string
     {
         $rule = [
             "\r" => '',
@@ -294,7 +245,7 @@ class Mail extends AbstractPart
      * @return $this
      * @throws InvalidArgumentException
      */
-    public function setReturnPath($address)
+    public function setReturnPath(string $address): self
     {
         if (filter_var($address, FILTER_VALIDATE_EMAIL) === false) {
             throw new InvalidArgumentException("Invalid email address ($address)");
@@ -303,23 +254,13 @@ class Mail extends AbstractPart
         return $this;
     }
 
-    /**
-     * Clear return path
-     *
-     * @return $this
-     */
-    public function clearReturnPath()
+    public function clearReturnPath(): self
     {
         $this->returnPath = null;
         return $this;
     }
 
-    /**
-     * Get return path
-     *
-     * @return string|null
-     */
-    public function getReturnPath()
+    public function getReturnPath(): ?string
     {
         return $this->returnPath;
     }
@@ -332,7 +273,7 @@ class Mail extends AbstractPart
      * @return $this
      * @throws InvalidArgumentException
      */
-    public function setFrom($address, $name = null)
+    public function setFrom(string $address, ?string $name = null): self
     {
         if (filter_var($address, FILTER_VALIDATE_EMAIL) === false) {
             throw new InvalidArgumentException("Invalid email address ($address)");
@@ -347,46 +288,23 @@ class Mail extends AbstractPart
         return $this;
     }
 
-    /**
-     * Get from
-     *
-     * @return array|null
-     */
-    public function getFrom()
+    public function getFrom(): ?array
     {
         return $this->from;
     }
 
-    /**
-     * Set subject
-     *
-     * @param string $subject
-     * @return $this
-     */
-    public function setSubject($subject)
+    public function setSubject(string $subject): self
     {
         $this->subject = $subject;
         return $this;
     }
 
-    /**
-     * Get subject
-     *
-     * @return string|null
-     */
-    public function getSubject()
+    public function getSubject(): ?string
     {
         return $this->subject;
     }
 
-    /**
-     * Format address
-     *
-     * @param string $address
-     * @param string $name
-     * @return string
-     */
-    public function formatAddress($address, $name = null)
+    public function formatAddress(string $address, ?string $name = null): string
     {
         if (!$name) {
             return $address;
@@ -399,56 +317,31 @@ class Mail extends AbstractPart
         }
     }
 
-    /**
-     * Return true if the mail has a part descendant which is an attachment
-     *
-     * @return bool
-     */
-    public function hasAttachment()
+    public function hasAttachment(): bool
     {
         return ($this->attachmentCount > 0);
     }
 
-    /**
-     * Return the number of attachments contains in the mail's descendants
-     *
-     * @return int
-     */
-    public function getAttachmentCount()
+    public function getAttachmentCount(): int
     {
         return $this->attachmentCount;
     }
 
-    /**
-     * Increment the number of attachments contained in this mail's descendants
-     *
-     * @return $this
-     */
-    public function incrementAttachmentCount()
+    public function incrementAttachmentCount(): self
     {
         $this->attachmentCount++;
 
         return $this;
     }
 
-    /**
-     * Decrement the number of attachments contained in this mail's descendants
-     *
-     * @return $this
-     */
-    public function decrementAttachmentCount()
+    public function decrementAttachmentCount(): self
     {
         $this->attachmentCount--;
 
         return $this;
     }
 
-    /**
-     * To string
-     *
-     * @return string
-     */
-    public function toString()
+    public function toString(): string
     {
         $result = $this->getEncodedHeaders() . $this->getPart()->toString();
         if (substr($result, -1) !== "\n") {

--- a/src/Mail.php
+++ b/src/Mail.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail;
 

--- a/src/Mail.php
+++ b/src/Mail.php
@@ -90,7 +90,7 @@ class Mail extends AbstractPart
 
     public function getEncodedHeaders(): string
     {
-        $headers = array();
+        $headers = [];
 
         if ($this->returnPath) {
             $headers[] = "Return-Path: <$this->returnPath>";
@@ -106,7 +106,7 @@ class Mail extends AbstractPart
         }
 
         if (!empty($this->to)) {
-            $to = array();
+            $to = [];
             foreach ($this->to as $address => $name) {
                 $to[] = $this->formatAddress($address, $name);
             }
@@ -114,7 +114,7 @@ class Mail extends AbstractPart
         }
 
         if (!empty($this->cc)) {
-            $cc = array();
+            $cc = [];
             foreach ($this->cc as $address => $name) {
                 $cc[] = $this->formatAddress($address, $name);
             }
@@ -166,7 +166,7 @@ class Mail extends AbstractPart
 
     public function clearTo(): self
     {
-        $this->to = array();
+        $this->to = [];
 
         return $this;
     }
@@ -191,7 +191,7 @@ class Mail extends AbstractPart
 
     public function clearCc(): self
     {
-        $this->cc = array();
+        $this->cc = [];
 
         return $this;
     }

--- a/src/Mime/AbstractMime.php
+++ b/src/Mime/AbstractMime.php
@@ -17,47 +17,24 @@ abstract class AbstractMime extends AbstractPart
      */
     private $boundary;
 
-    /**
-     * Set boundary
-     *
-     * @param string $boundary
-     * @return AbstractMime
-     */
-    private function setBoundary($boundary)
+    private function setBoundary(string $boundary): self
     {
         $this->boundary = $boundary;
         return $this;
     }
 
-    /**
-     * Get boundary
-     *
-     * @return string
-     */
-    public function getBoundary()
+    public function getBoundary(): ?string
     {
         return $this->boundary;
     }
 
-    /**
-     * Add part
-     *
-     * @param AbstractPart $part
-     * @return AbstractPart
-     */
-    public function addPart(AbstractPart $part)
+    public function addPart(AbstractPart $part): AbstractPart
     {
         $this->parts[] = $part;
         return $part;
     }
 
-    /**
-     * Set parts
-     *
-     * @param array $parts
-     * @return AbstractMime
-     */
-    public function setParts(array $parts)
+    public function setParts(array $parts): self
     {
         $this->clearParts();
         foreach ($parts as $part) {
@@ -66,12 +43,7 @@ abstract class AbstractMime extends AbstractPart
         return $this;
     }
 
-    /**
-     * Clear parts
-     *
-     * @return AbstractMime
-     */
-    public function clearParts()
+    public function clearParts(): self
     {
         $this->parts = array();
         return $this;
@@ -82,17 +54,12 @@ abstract class AbstractMime extends AbstractPart
      *
      * @return AbstractPart[]
      */
-    public function getParts()
+    public function getParts(): array
     {
         return $this->parts;
     }
 
-    /**
-     * To string
-     *
-     * @return string
-     */
-    public function toString()
+    public function toString(): string
     {
         $pieces = array();
         foreach ($this->getParts() as $part) {
@@ -119,7 +86,7 @@ abstract class AbstractMime extends AbstractPart
      * @param string $contentType
      * @return string
      */
-    protected function addContentTypeParameters($contentType)
+    protected function addContentTypeParameters(string $contentType): string
     {
         if ($this->boundary) {
             $contentType .= ";\r\n\tboundary=\"{$this->boundary}\"";

--- a/src/Mime/AbstractMime.php
+++ b/src/Mime/AbstractMime.php
@@ -10,7 +10,7 @@ abstract class AbstractMime extends AbstractPart
     /**
      * @var AbstractPart[]
      */
-    private $parts = array();
+    private $parts = [];
 
     /**
      * @var string
@@ -45,7 +45,7 @@ abstract class AbstractMime extends AbstractPart
 
     public function clearParts(): self
     {
-        $this->parts = array();
+        $this->parts = [];
         return $this;
     }
 
@@ -61,7 +61,7 @@ abstract class AbstractMime extends AbstractPart
 
     public function toString(): string
     {
-        $pieces = array();
+        $pieces = [];
         foreach ($this->getParts() as $part) {
             $pieces[] = $part->toString();
         }

--- a/src/Mime/AbstractMime.php
+++ b/src/Mime/AbstractMime.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Mime;
 

--- a/src/Mime/Mime.php
+++ b/src/Mime/Mime.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Mime;
 

--- a/src/Mime/MultipartAlternative.php
+++ b/src/Mime/MultipartAlternative.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Mime;
 

--- a/src/Mime/MultipartMixed.php
+++ b/src/Mime/MultipartMixed.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Mime;
 

--- a/src/Mime/MultipartRelated.php
+++ b/src/Mime/MultipartRelated.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Mime;
 

--- a/src/Mime/MultipartReport.php
+++ b/src/Mime/MultipartReport.php
@@ -21,7 +21,7 @@ class MultipartReport extends AbstractMime
      * @param string $reportType
      * @return $this
      */
-    public function setReportType($reportType)
+    public function setReportType(string $reportType): self
     {
         $this->reportType = $reportType;
 
@@ -33,7 +33,7 @@ class MultipartReport extends AbstractMime
      *
      * @return string
      */
-    public function getReportType()
+    public function getReportType(): string
     {
         return $this->reportType;
     }
@@ -44,7 +44,7 @@ class MultipartReport extends AbstractMime
      * @param string $contentType
      * @return string
      */
-    protected function addContentTypeParameters($contentType)
+    protected function addContentTypeParameters(string $contentType): string
     {
         if ($this->reportType) {
             $contentType .= "; report-type={$this->reportType}";

--- a/src/Mime/MultipartReport.php
+++ b/src/Mime/MultipartReport.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Mime;
 

--- a/tests/AbstractPartTest.php
+++ b/tests/AbstractPartTest.php
@@ -5,8 +5,9 @@ namespace Phlib\Mail\Tests;
 
 use Phlib\Mail\AbstractPart;
 use Phlib\Mail\Exception\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 
-class AbstractPartTest extends \PHPUnit_Framework_TestCase
+class AbstractPartTest extends TestCase
 {
     /**
      * @var AbstractPart

--- a/tests/AbstractPartTest.php
+++ b/tests/AbstractPartTest.php
@@ -127,7 +127,7 @@ class AbstractPartTest extends TestCase
 
         $this->part->clearHeaders();
         $actualAfter = $this->part->getHeaders();
-        $this->assertEquals(array(), $actualAfter);
+        $this->assertEquals([], $actualAfter);
     }
 
     public function testHasHeaderFalse()

--- a/tests/AbstractPartTest.php
+++ b/tests/AbstractPartTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Tests;
 

--- a/tests/AssertAttachmentsEmail.php
+++ b/tests/AssertAttachmentsEmail.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Tests;
 

--- a/tests/AssertAttachmentsEmail.php
+++ b/tests/AssertAttachmentsEmail.php
@@ -58,47 +58,47 @@ class AssertAttachmentsEmail
 
         // Check part content
         $content = [
-            'text' => array(
+            'text' => [
                 'part' => $alternateParts[0]
-            ),
-            'html' => array(
+            ],
+            'html' => [
                 'part' => $alternateParts[1]
-            ),
-            'attch1' => array(
+            ],
+            'attch1' => [
                 'part' => $relatedParts[1],
                 'disposition' => false,
                 'name' => '330.gif',
                 'charset' => false,
                 'type' => 'image/gif'
-            ),
-            'attch2' => array(
+            ],
+            'attch2' => [
                 'part' => $mixedParts[1],
                 'disposition' => true,
                 'name' => 'protocol.txt',
                 'charset' => 'US-ASCII',
                 'type' => 'text/plain'
-            ),
-            'attch3' => array(
+            ],
+            'attch3' => [
                 'part' => $mixedParts[2],
                 'disposition' => true,
                 'name' => 'example-logo.png',
                 'charset' => false,
                 'type' => 'image/png'
-            ),
-            'attch4' => array(
+            ],
+            'attch4' => [
                 'part' => $mixedParts[3],
                 'disposition' => true,
                 'name' => 'Tech_specs-letter_Crucial_m4_ssd_v3-11-11_online.pdf',
                 'charset' => false,
                 'type' => 'application/pdf'
-            ),
-            'attch5' => array(
+            ],
+            'attch5' => [
                 'part' => $mixedParts[4],
                 'disposition' => true,
                 'name' => 'plain.eml',
                 'charset' => 'US-ASCII',
                 'type' => 'text/plain'
-            )
+            ]
         ];
 
         foreach ($content as $name => $details) {

--- a/tests/AssertBounceHeadEmail.php
+++ b/tests/AssertBounceHeadEmail.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Tests;
 

--- a/tests/AssertBounceMsgEmail.php
+++ b/tests/AssertBounceMsgEmail.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Tests;
 

--- a/tests/AssertContentAttachmentEmail.php
+++ b/tests/AssertContentAttachmentEmail.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Tests;
 

--- a/tests/AssertHtmlEmail.php
+++ b/tests/AssertHtmlEmail.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Tests;
 

--- a/tests/Content/AbstractContentTest.php
+++ b/tests/Content/AbstractContentTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Tests\Content;
 

--- a/tests/Content/AbstractContentTest.php
+++ b/tests/Content/AbstractContentTest.php
@@ -5,8 +5,9 @@ namespace Phlib\Mail\Tests\Content;
 
 use Phlib\Mail\AbstractPart;
 use Phlib\Mail\Content\AbstractContent;
+use PHPUnit\Framework\TestCase;
 
-class AbstractContentTest extends \PHPUnit_Framework_TestCase
+class AbstractContentTest extends TestCase
 {
     /**
      * @var AbstractContent

--- a/tests/Content/AttachmentTest.php
+++ b/tests/Content/AttachmentTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Tests\Content;
 

--- a/tests/Content/AttachmentTest.php
+++ b/tests/Content/AttachmentTest.php
@@ -6,8 +6,9 @@ namespace Phlib\Mail\Tests\Content;
 use Phlib\Mail\AbstractPart;
 use Phlib\Mail\Content\Attachment;
 use Phlib\Mail\Exception\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 
-class AttachmentTest extends \PHPUnit_Framework_TestCase
+class AttachmentTest extends TestCase
 {
     public function testCreateFromFile()
     {

--- a/tests/Content/ContentTest.php
+++ b/tests/Content/ContentTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Tests\Content;
 

--- a/tests/Content/ContentTest.php
+++ b/tests/Content/ContentTest.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 namespace Phlib\Mail\Tests\Content;
 
 use Phlib\Mail\Content\Content;
+use PHPUnit\Framework\TestCase;
 
-class ContentTest extends \PHPUnit_Framework_TestCase
+class ContentTest extends TestCase
 {
     public function testGetTypeDefault()
     {

--- a/tests/Content/HtmlTest.php
+++ b/tests/Content/HtmlTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Tests\Content;
 

--- a/tests/Content/HtmlTest.php
+++ b/tests/Content/HtmlTest.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 namespace Phlib\Mail\Tests\Content;
 
 use Phlib\Mail\Content\Html;
+use PHPUnit\Framework\TestCase;
 
-class HtmlTest extends \PHPUnit_Framework_TestCase
+class HtmlTest extends TestCase
 {
     /**
      * @var Html

--- a/tests/Content/TextTest.php
+++ b/tests/Content/TextTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Tests\Content;
 

--- a/tests/Content/TextTest.php
+++ b/tests/Content/TextTest.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 namespace Phlib\Mail\Tests\Content;
 
 use Phlib\Mail\Content\Text;
+use PHPUnit\Framework\TestCase;
 
-class TextTest extends \PHPUnit_Framework_TestCase
+class TextTest extends TestCase
 {
     /**
      * @var Text

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -7,8 +7,9 @@ use Phlib\Mail\Exception\RuntimeException;
 use Phlib\Mail\Factory;
 use Phlib\Mail\Mime\AbstractMime;
 use phpmock\phpunit\PHPMock;
+use PHPUnit\Framework\TestCase;
 
-class FactoryTest extends \PHPUnit_Framework_TestCase
+class FactoryTest extends TestCase
 {
     use PHPMock;
 

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Tests;
 

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Tests;
 

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -10,8 +10,9 @@ use Phlib\Mail\Content\Text;
 use Phlib\Mail\Factory;
 use Phlib\Mail\Mime\AbstractMime;
 use Phlib\Mail\Mime\MultipartAlternative;
+use PHPUnit\Framework\TestCase;
 
-class IntegrationTest extends \PHPUnit_Framework_TestCase
+class IntegrationTest extends TestCase
 {
 
     public function testRecreateMultipartMail()

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Tests;
 

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -8,8 +8,9 @@ use Phlib\Mail\Exception\InvalidArgumentException;
 use Phlib\Mail\Exception\RuntimeException;
 use Phlib\Mail\Mail;
 use Phlib\Mail\Mime\Mime;
+use PHPUnit\Framework\TestCase;
 
-class MailTest extends \PHPUnit_Framework_TestCase
+class MailTest extends TestCase
 {
     /**
      * @var \Phlib\Mail\Mail

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -106,7 +106,7 @@ class MailTest extends TestCase
         $this->assertEquals($expectedBefore, $this->mail->getTo());
 
         $this->mail->clearTo();
-        $expectedAfter = array();
+        $expectedAfter = [];
         $this->assertEquals($expectedAfter, $this->mail->getTo());
     }
 
@@ -136,7 +136,7 @@ class MailTest extends TestCase
         $this->assertEquals($expectedBefore, $this->mail->getCc());
 
         $this->mail->clearCc();
-        $expectedAfter = array();
+        $expectedAfter = [];
         $this->assertEquals($expectedAfter, $this->mail->getCc());
     }
 

--- a/tests/Mime/AbstractMimeTest.php
+++ b/tests/Mime/AbstractMimeTest.php
@@ -78,12 +78,12 @@ class AbstractMimeTest extends TestCase
         $this->assertEquals($expectedBefore, $this->part->getParts());
 
         $this->part->clearParts();
-        $this->assertEquals(array(), $this->part->getParts());
+        $this->assertEquals([], $this->part->getParts());
     }
 
     public function testGetPartsDefault()
     {
-        $this->assertEquals(array(), $this->part->getParts());
+        $this->assertEquals([], $this->part->getParts());
     }
 
     /**
@@ -93,7 +93,7 @@ class AbstractMimeTest extends TestCase
      */
     public function testToString()
     {
-        $expected = array();
+        $expected = [];
 
         $this->part->addHeader('test-header', 'header value');
         $expected[] = "Test-Header: header value\r\n";

--- a/tests/Mime/AbstractMimeTest.php
+++ b/tests/Mime/AbstractMimeTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Tests\Mime;
 

--- a/tests/Mime/AbstractMimeTest.php
+++ b/tests/Mime/AbstractMimeTest.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 namespace Phlib\Mail\Tests\Mime;
 
 use Phlib\Mail\Mime\AbstractMime;
+use PHPUnit\Framework\TestCase;
 
-class AbstractMimeTest extends \PHPUnit_Framework_TestCase
+class AbstractMimeTest extends TestCase
 {
     /**
      * @var AbstractMime

--- a/tests/Mime/MimeTest.php
+++ b/tests/Mime/MimeTest.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 namespace Phlib\Mail\Tests\Mime;
 
 use Phlib\Mail\Mime\Mime;
+use PHPUnit\Framework\TestCase;
 
-class MimeTest extends \PHPUnit_Framework_TestCase
+class MimeTest extends TestCase
 {
     public function testSetGetType()
     {

--- a/tests/Mime/MimeTest.php
+++ b/tests/Mime/MimeTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Tests\Mime;
 

--- a/tests/Mime/MultipartAlternativeTest.php
+++ b/tests/Mime/MultipartAlternativeTest.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 namespace Phlib\Mail\Tests\Mime;
 
 use Phlib\Mail\Mime\MultipartAlternative;
+use PHPUnit\Framework\TestCase;
 
-class MultipartAlternativeTest extends \PHPUnit_Framework_TestCase
+class MultipartAlternativeTest extends TestCase
 {
     /**
      * @var MultipartAlternative

--- a/tests/Mime/MultipartAlternativeTest.php
+++ b/tests/Mime/MultipartAlternativeTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Tests\Mime;
 

--- a/tests/Mime/MultipartMixedTest.php
+++ b/tests/Mime/MultipartMixedTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Tests\Mime;
 

--- a/tests/Mime/MultipartMixedTest.php
+++ b/tests/Mime/MultipartMixedTest.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 namespace Phlib\Mail\Tests\Mime;
 
 use Phlib\Mail\Mime\MultipartMixed;
+use PHPUnit\Framework\TestCase;
 
-class MultipartMixedTest extends \PHPUnit_Framework_TestCase
+class MultipartMixedTest extends TestCase
 {
     /**
      * @var MultipartMixed

--- a/tests/Mime/MultipartRelatedTest.php
+++ b/tests/Mime/MultipartRelatedTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Tests\Mime;
 

--- a/tests/Mime/MultipartRelatedTest.php
+++ b/tests/Mime/MultipartRelatedTest.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 namespace Phlib\Mail\Tests\Mime;
 
 use Phlib\Mail\Mime\MultipartRelated;
+use PHPUnit\Framework\TestCase;
 
-class MultipartRelatedTest extends \PHPUnit_Framework_TestCase
+class MultipartRelatedTest extends TestCase
 {
     /**
      * @var MultipartRelated

--- a/tests/Mime/MultipartReportTest.php
+++ b/tests/Mime/MultipartReportTest.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 namespace Phlib\Mail\Tests\Mime;
 
 use Phlib\Mail\Mime\MultipartReport;
+use PHPUnit\Framework\TestCase;
 
-class MultipartReportTest extends \PHPUnit_Framework_TestCase
+class MultipartReportTest extends TestCase
 {
     /**
      * @var MultipartReport

--- a/tests/Mime/MultipartReportTest.php
+++ b/tests/Mime/MultipartReportTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Phlib\Mail\Tests\Mime;
 


### PR DESCRIPTION
* Remove support for PHP 5.x and 7.0
* Add PHP 7.1 features: strict types and scalar type declarations
* Also upgraded to PHPUnit 7

This will be a major version bump