### PR TITLE
Remove deprecations for v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - PHP 7.1 scalar type declarations and return types
 ### Removed
-- Removed support for PHP 5.x and 7.0 as they are no longer
+- **BC break**: Removed support for PHP 5.x and 7.0 as they are no longer
 [actively supported](https://php.net/supported-versions.php) by the PHP project
+- **BC break**: Removed deprecated methods:
+    - `Factory::fromFile()`
+    - `Factory::fromString()`
+    - `Factory::decodeHeader()`
+    - `Factory::parseEmailAddresses()`
 
 ## [2.1.1] - 2018-03-19
 ### Fixed

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -65,16 +65,6 @@ class Factory
     }
 
     /**
-     * @deprecated 2.1.0:3.0.0 Use createFromFile() to avoid statics and allow for the Factory to be used in DI
-     * @param string $filename
-     * @return Mail
-     */
-    public static function fromFile(string $filename): Mail
-    {
-        return (new self)->createFromFile($filename);
-    }
-
-    /**
      * Load email from string
      *
      * @param string $source email as string
@@ -106,16 +96,6 @@ class Factory
                 $this->structure
             );
         }
-    }
-
-    /**
-     * @deprecated 2.1.0:3.0.0 Use createFromString() to avoid statics and allow for the Factory to be used in DI
-     * @param string $source
-     * @return Mail
-     */
-    public static function fromString(string $source): Mail
-    {
-        return (new self)->createFromString($source);
     }
 
     /**
@@ -341,7 +321,6 @@ class Factory
     /**
      * Decode header
      *
-     * @deprecated 2.1.0:3.0.0 Method should not have been available in the public interface
      * @param string $header Encoded header
      * @param string $charset Target charset. Optional. Default will use source charset where available.
      * @return array {
@@ -350,7 +329,7 @@ class Factory
      * }
      * @throws InvalidArgumentException
      */
-    public function decodeHeader(string $header, ?string $charset = null): array
+    private function decodeHeader(string $header, ?string $charset = null): array
     {
         if (preg_match('/=\?([^\?]+)\?([^\?])\?[^\?]+\?=/', $header, $matches) > 0) {
             if ($charset === null) {
@@ -374,13 +353,11 @@ class Factory
     /**
      * Parse RFC 822 formatted email addresses string
      *
-     * @deprecated 2.1.0:3.0.0 Method should not have been available in the public interface
      * @see mailparse_rfc822_parse_addresses()
      * @param string $addresses
      * @return array 'display', 'address' and 'is_group'
-     * @see mailparse_rfc822_parse_addresses
      */
-    public function parseEmailAddresses(string $addresses): array
+    private function parseEmailAddresses(string $addresses): array
     {
         return mailparse_rfc822_parse_addresses($addresses);
     }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -330,31 +330,6 @@ class FactoryTest extends TestCase
     }
 
     /**
-     * @deprecated 2.1.0:3.0.0 Method should not have been available in the public interface
-     */
-    public function testParseEmailAddresses()
-    {
-        $factory = new Factory();
-
-        $addresses = 'recipient1@example.com, "Recipient Two" <recipient2@example.com>';
-
-        $expected = [
-            0 => [
-                'display'  => 'recipient1@example.com',
-                'address'  => 'recipient1@example.com',
-                'is_group' => false,
-            ],
-            1 => [
-                'display'  => 'Recipient Two',
-                'address'  => 'recipient2@example.com',
-                'is_group' => false,
-            ]
-        ];
-
-        $this->assertEquals($expected, $factory->parseEmailAddresses($addresses));
-    }
-
-    /**
      * Invoke Factory::decodeHeader()
      *
      * @see Factory::decodeHeader()


### PR DESCRIPTION
This removes methods (or public access to them) which you've previously marked as deprecated, to be removed in v3.

This must be released in v3.0.0