### PR TITLE
Prevent Message-Id header from being encoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     - `Factory::fromString()`
     - `Factory::decodeHeader()`
     - `Factory::parseEmailAddresses()`
+- **BC break**: Removed `AbstractPart::encodeHeader()`
 
 ## [2.1.1] - 2018-03-19
 ### Fixed

--- a/src/AbstractPart.php
+++ b/src/AbstractPart.php
@@ -227,7 +227,7 @@ abstract class AbstractPart
         return $this->type;
     }
 
-    public function encodeHeader(string $header): string
+    protected function encodeHeader(string $header): string
     {
         $charset = $this->charset;
         if (!$charset) {

--- a/src/Mail.php
+++ b/src/Mail.php
@@ -98,11 +98,11 @@ class Mail extends AbstractPart
 
         if ($this->from) {
             list($address, $name) = $this->from;
-            $headers[] = $this->encodeHeader('From: ' . $this->formatAddress($address, $name));
+            $headers[] = $this->encodeHeader('From', $this->formatAddress($address, $name));
         }
 
         if ($this->subject) {
-            $headers[] = $this->encodeHeader('Subject: ' . $this->subject);
+            $headers[] = $this->encodeHeader('Subject', $this->subject);
         }
 
         if (!empty($this->to)) {
@@ -110,7 +110,7 @@ class Mail extends AbstractPart
             foreach ($this->to as $address => $name) {
                 $to[] = $this->formatAddress($address, $name);
             }
-            $headers[] = $this->encodeHeader('To: ' . rtrim(implode(",\r\n ", $to)));
+            $headers[] = $this->encodeHeader('To', rtrim(implode(",\r\n ", $to)));
         }
 
         if (!empty($this->cc)) {
@@ -118,12 +118,12 @@ class Mail extends AbstractPart
             foreach ($this->cc as $address => $name) {
                 $cc[] = $this->formatAddress($address, $name);
             }
-            $headers[] = $this->encodeHeader('Cc: ' . rtrim(implode(",\r\n ", $cc)));
+            $headers[] = $this->encodeHeader('Cc', rtrim(implode(",\r\n ", $cc)));
         }
 
         if ($this->replyTo) {
             list($address, $name) = $this->replyTo;
-            $headers[] = $this->encodeHeader('Reply-To: ' . $this->formatAddress($address, $name));
+            $headers[] = $this->encodeHeader('Reply-To', $this->formatAddress($address, $name));
         }
 
         if ($this->getPart() instanceof Mime\AbstractMime) {

--- a/tests/AbstractPartTest.php
+++ b/tests/AbstractPartTest.php
@@ -146,10 +146,16 @@ class AbstractPartTest extends TestCase
 
     public function testGetEncodedHeaders()
     {
-        $expected = $this->addHeaders();
+        // Multiple basic headers
+        $expected = $this->addHeaders()[1];
+
+        // Check encoding
+        $value = "line1\r\nline2, high ascii > é <\r\n";
+        $this->part->addHeader('Subject', $value);
+        $expected .= "Subject: line1line2, high ascii > =?UTF-8?B?" . base64_encode('é <') . "?=\r\n";
 
         $actual = $this->part->getEncodedHeaders();
-        $this->assertEquals($expected[1], $actual);
+        $this->assertEquals($expected, $actual);
     }
 
     /**
@@ -192,17 +198,6 @@ class AbstractPartTest extends TestCase
     {
         $type = null;
         $this->assertEquals($type, $this->part->getType());
-    }
-
-    public function testEncodeHeader()
-    {
-        $value    = "line1\r\nline2, high ascii > é <\r\n";
-        $header   = "Subject: {$value}";
-        $expected = "Subject: =?UTF-8?B?" . base64_encode($value) . "?=";
-
-        $this->part->setCharset('UTF-8');
-        $actual = $this->part->encodeHeader($header);
-        $this->assertEquals($expected, $actual);
     }
 
     /**

--- a/tests/AbstractPartTest.php
+++ b/tests/AbstractPartTest.php
@@ -159,6 +159,22 @@ class AbstractPartTest extends TestCase
     }
 
     /**
+     * Message-Id header must never be encoded
+     * An underscore triggers mb_encode_mimeheader() to encode the string even if not necessary
+     */
+    public function testGetEncodedHeadersMessageId()
+    {
+        $name = 'Message-Id';
+        $value = '<5ba50e335feeb_58fbb46426474f8d8108b1f8e02bad29@mail.example.com>';
+        $this->part->addHeader($name, $value);
+
+        $expected = "$name: $value\r\n";
+
+        $actual = $this->part->getEncodedHeaders();
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
      * @dataProvider dataSetGetEncodingValid
      */
     public function testSetGetEncodingValid($encoding)

--- a/tests/__files/attachments-expected-headers.txt
+++ b/tests/__files/attachments-expected-headers.txt
@@ -49,5 +49,4 @@ Dkim-Signature: =?UTF-8?B?dj0xOyBhPXJzYS1zaGEyNTY7IGM9cmVsYXhlZC9yZWxh?=
  =?UTF-8?B?Qmdrblk4RTZieE5JdElpRGFKOXZIR0x2eU1aaiAgICAgICAgIDZTR2c9PQ==?=
 X-Goomoji-Body: true
 Date: Thu, 16 Aug 2012 15:45:32 +0100
-Message-Id: =?UTF-8?B?PENBSl9UUm5MPVlNT2JmMkZUOWJVN05PMHppUFl4cG54Znhy?=
- =?UTF-8?B?dE96NHIyLWFCeGtIU09yQUBtYWlsLmdtYWlsLmNvbT4=?=
+Message-Id: <CAJ_TRnL=YMObf2FT9bU7NO0ziPYxpnxfxrtOz4r2-aBxkHSOrA@mail.gmail.com>


### PR DESCRIPTION
*Message-Id* has a specific syntax which does not allow for encoding, which `mb_encode_mimeheader()` will do if it detects any non-ASCII or reserved characters, eg: `_`

**BC break** as `AbstractPart::encodeHeader()` is removed from public visibility.