### PR TITLE
Header softwrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- No longer encode pure-ASCII headers.
+ [RFC2047 'encoded-word'](https://tools.ietf.org/html/rfc2047#section-2)
+ syntax is only used when non-ASCII characters are detected.
 
 ## [3.1.0] - 2018-09-25
 ### Fixed

--- a/src/AbstractPart.php
+++ b/src/AbstractPart.php
@@ -232,10 +232,19 @@ abstract class AbstractPart
         $header = "$name: " . trim($value);
         // RFC5335 Internationalized Email Headers, Section 4.3 disallows UTF-8 chars for Message-Id
         // RFC5322 Internet Message Format, Section 3.6.4 has strict control on the syntax of Message-Id
-        // mb_internal_encoding() does not check for this, and will encode the header value if any non-ASCII or reserved
+        // mb_encode_mimeheader() does not check for this, and will encode the header value if any non-ASCII or reserved
         // characters are present (eg. '_')
         if (strtolower($name) === 'message-id') {
             return $header;
+        }
+        // Even if content is all ASCII, mb_encode_mimeheader() would encode it if the header length exceeds 78 chars.
+        // wordwrap() doesn't account for the 4 spaces added after the new line-break, so break instead at 74.
+        if (mb_check_encoding($header, 'ASCII') === true) {
+            if (strlen($header) <= 78) {
+                return $header;
+            }
+            return substr($header, 0, 4) .
+                wordwrap(substr($header, 4), 74, "\r\n    ", false);
         }
         $charset = $this->charset;
         if (!$charset) {

--- a/src/AbstractPart.php
+++ b/src/AbstractPart.php
@@ -229,7 +229,7 @@ abstract class AbstractPart
 
     protected function encodeHeader(string $name, string $value): string
     {
-        $header = "$name: $value";
+        $header = "$name: " . trim($value);
         // RFC5335 Internationalized Email Headers, Section 4.3 disallows UTF-8 chars for Message-Id
         // RFC5322 Internet Message Format, Section 3.6.4 has strict control on the syntax of Message-Id
         // mb_internal_encoding() does not check for this, and will encode the header value if any non-ASCII or reserved

--- a/tests/AbstractPartTest.php
+++ b/tests/AbstractPartTest.php
@@ -158,6 +158,18 @@ class AbstractPartTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
+    public function testGetEncodedHeadersWhitespace()
+    {
+        $name = 'From';
+        $value = ' "From" <from@mail.example.com> ';
+        $this->part->addHeader($name, $value);
+
+        $expected = "$name: " . trim($value) . "\r\n";
+
+        $actual = $this->part->getEncodedHeaders();
+        $this->assertEquals($expected, $actual);
+    }
+
     /**
      * Message-Id header must never be encoded
      * An underscore triggers mb_encode_mimeheader() to encode the string even if not necessary

--- a/tests/AbstractPartTest.php
+++ b/tests/AbstractPartTest.php
@@ -248,8 +248,8 @@ class AbstractPartTest extends TestCase
             // Test very long
             ['Dkim-Signature', [
                 'v=1; a=rsa-sha256; c=relaxed/relaxed; d=gmail.com; s=20120113;',
-                'h=mime-version:x-goomoji-body:date:message-id:subject:from:to:content-type;',
-                'bh=axdcMS9VSIT9/g8h/o69GDtb4N1cYQ2rUOrvm7/46DU=;',
+                'h=mime-version:x-goomoji-body:date:message-id:subject:from:to:',
+                'content-type;bh=axdcMS9VSIT9/g8h/o69GDtb4N1cYQ2rUOrvm7/46DU=;',
                 'b=zw0iOrFoyB1gn/qiFdguXs4OM7UB0d4kT6OOBq8JY/1BQAlS9j+itqA+nezoFg84a3',
                 'ONxbn4my2RZLv9SSKYRsNr+SOMPsEAjNJJGoWacE7/JmW7iVCWpGB0co7Ejxhr3EwUM0',
                 'G2fZB7/cQrV7zYIrkkoetRWYTqTvOt7W8lfEJaLXFOSATqW/Xcaos5BWo88rJImDWrew',

--- a/tests/AbstractPartTest.php
+++ b/tests/AbstractPartTest.php
@@ -173,17 +173,90 @@ class AbstractPartTest extends TestCase
     /**
      * Message-Id header must never be encoded
      * An underscore triggers mb_encode_mimeheader() to encode the string even if not necessary
+     * Even when longer than soft limit of 78 chars, we don't want Message-Id to be wrapped
      */
     public function testGetEncodedHeadersMessageId()
     {
         $name = 'Message-Id';
-        $value = '<5ba50e335feeb_58fbb46426474f8d8108b1f8e02bad29@mail.example.com>';
+        $value = '<5ba50e335feeb_58fbb46426474f8d8108b1f8e02bad29@mail.long.example.com>';
         $this->part->addHeader($name, $value);
 
         $expected = "$name: $value\r\n";
 
         $actual = $this->part->getEncodedHeaders();
         $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * An underscore triggers mb_encode_mimeheader() to encode the string even if not necessary
+     */
+    public function testGetEncodedHeadersNotEncodedForUnderscore()
+    {
+        $name = 'Subject';
+        $value = 'Latest _offers_';
+        $this->part->addHeader($name, $value);
+
+        $expected = "$name: $value\r\n";
+
+        $actual = $this->part->getEncodedHeaders();
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * An equals triggers mb_encode_mimeheader() to encode the string even if not necessary
+     */
+    public function testGetEncodedHeadersNotEncodedForEquals()
+    {
+        $name = 'From';
+        $value = '"From=" <equals@mail.example.com>';
+        $this->part->addHeader($name, $value);
+
+        $expected = "$name: $value\r\n";
+
+        $actual = $this->part->getEncodedHeaders();
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Long header in pure ASCII should not be encoded, but should be wrapped at 78 chars
+     * @dataProvider dataGetEncodedHeadersNotEncodedWillSoftWrap
+     */
+    public function testGetEncodedHeadersNotEncodedWillSoftWrap($name, $valueParts)
+    {
+        $this->part->addHeader($name, implode(' ', $valueParts));
+
+        $expected = "$name: " . implode("\r\n    ", $valueParts) . "\r\n";
+
+        $actual = $this->part->getEncodedHeaders();
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function dataGetEncodedHeadersNotEncodedWillSoftWrap()
+    {
+        return [
+            // First line is exactly 78 chars
+            ['Received', [
+                'by 10.50.76.202 with SMTP id m10mr1877022igw.52.1345128339903; Thu,',
+                '16 Aug 2012 07:45:39 -0700 (PDT)'
+            ]],
+            // Test multiple lines
+            ['Received', [
+                'from mail-yx0-f181.google.com (mail-yx0-f181.google.com',
+                '[209.85.213.181]) by mail.example.com (Postfix) with ESMTPS id 92F4A161D85',
+                'for <recipient@example.com>; Thu, 16 Aug 2012 15:45:41 +0100 (BST)'
+            ]],
+            // Test very long
+            ['Dkim-Signature', [
+                'v=1; a=rsa-sha256; c=relaxed/relaxed; d=gmail.com; s=20120113;',
+                'h=mime-version:x-goomoji-body:date:message-id:subject:from:to:content-type;',
+                'bh=axdcMS9VSIT9/g8h/o69GDtb4N1cYQ2rUOrvm7/46DU=;',
+                'b=zw0iOrFoyB1gn/qiFdguXs4OM7UB0d4kT6OOBq8JY/1BQAlS9j+itqA+nezoFg84a3',
+                'ONxbn4my2RZLv9SSKYRsNr+SOMPsEAjNJJGoWacE7/JmW7iVCWpGB0co7Ejxhr3EwUM0',
+                'G2fZB7/cQrV7zYIrkkoetRWYTqTvOt7W8lfEJaLXFOSATqW/Xcaos5BWo88rJImDWrew',
+                '1k3YbnNs0jyXvPO+jytUfWEkDPu7w1k+K9TqvHtGeawyj21QeNmo1Z1P//g29MO61m/N',
+                'bU+IexdOG/O4XcauU1Qk8gGm0xA3szGZXGaaji8eBgknY8E6bxNItIiDaJ9vHGLvyMZj6SGg=='
+            ]]
+        ];
     }
 
     /**

--- a/tests/__files/attachments-expected-headers.txt
+++ b/tests/__files/attachments-expected-headers.txt
@@ -4,49 +4,43 @@ Subject: Attachments
 To: recipient@example.com
 MIME-Version: 1.0
 Received: from mail.example.com (LHLO mail.example.com) (10.1.9.1) by
- mail.example.com with LMTP; Thu, 16 Aug 2012 15:45:43 +0100 (BST)
-Received: from localhost (localhost [127.0.0.1]) by mail.example.com
- (Postfix) with ESMTP id ED35D161D86 for <recipient@example.com>; Thu, 16
- Aug 2012 15:45:43 +0100 (BST)
-Received: from mail.example.com ([127.0.0.1]) by localhost
- (mail.example.com [127.0.0.1]) (amavisd-new, port 10024) with ESMTP id
- x9xbo4ZNbRu7 for <recipient@example.com>; Thu, 16 Aug 2012 15:45:42 +0100
- (BST)
+    mail.example.com with LMTP; Thu, 16 Aug 2012 15:45:43 +0100 (BST)
+Received: from localhost (localhost [127.0.0.1]) by mail.example.com (Postfix)
+    with ESMTP id ED35D161D86 for <recipient@example.com>; Thu, 16 Aug 2012
+    15:45:43 +0100 (BST)
+Received: from mail.example.com ([127.0.0.1]) by localhost (mail.example.com
+    [127.0.0.1]) (amavisd-new, port 10024) with ESMTP id x9xbo4ZNbRu7 for
+    <recipient@example.com>; Thu, 16 Aug 2012 15:45:42 +0100 (BST)
 Received: from mail-yx0-f181.google.com (mail-yx0-f181.google.com
- [209.85.213.181]) by mail.example.com (Postfix) with ESMTPS id 92F4A161D85
- for <recipient@example.com>; Thu, 16 Aug 2012 15:45:41 +0100 (BST)
+    [209.85.213.181]) by mail.example.com (Postfix) with ESMTPS id 92F4A161D85
+    for <recipient@example.com>; Thu, 16 Aug 2012 15:45:41 +0100 (BST)
 Received: by yenq13 with SMTP id q13so3462367yen.40        for
- <recipient@example.com>; Thu, 16 Aug 2012 07:45:40 -0700 (PDT)
-Received: by 10.50.76.202 with SMTP id m10mr1877022igw.52.1345128339903;
- Thu, 16 Aug 2012 07:45:39 -0700 (PDT)
+    <recipient@example.com>; Thu, 16 Aug 2012 07:45:40 -0700 (PDT)
+Received: by 10.50.76.202 with SMTP id m10mr1877022igw.52.1345128339903; Thu,
+    16 Aug 2012 07:45:39 -0700 (PDT)
 Received: by 10.64.82.163 with HTTP; Thu, 16 Aug 2012 07:45:32 -0700 (PDT)
 X-Virus-Scanned: amavisd-new at example.com
 X-Spam-Flag: NO
 X-Spam-Score: -1.507
-X-Spam-Level:
-X-Spam-Status: No, =?UTF-8?B?c2NvcmU9LTEuNTA3IHRhZ2dlZF9hYm92ZT0tMTAgcmVx?=
- =?UTF-8?B?dWlyZWQ9Ni42IHRlc3RzPVtCQVlFU18wMD0tMS45LCBES0lNX1NJR05FRD0w?=
- =?UTF-8?B?LjEsIERLSU1fVkFMSUQ9LTAuMSwgREtJTV9WQUxJRF9BVT0tMC4xLCBGUkVF?=
- =?UTF-8?B?TUFJTF9GUk9NPTAuMDAxLCBIVE1MX0lNQUdFX09OTFlfMDQ9MS4xNzIsIEhU?=
- =?UTF-8?B?TUxfTUVTU0FHRT0wLjAwMSwgUkNWRF9JTl9ETlNXTF9MT1c9LTAuNywgU1BG?=
- =?UTF-8?B?X1BBU1M9LTAuMDAxLCBUX0ZSRUVNQUlMX0RPQ19QREY9MC4wMSwgVF9UT19O?=
- =?UTF-8?B?T19CUktUU19GUkVFTUFJTD0wLjAxXSBhdXRvbGVhcm49aGFt?=
-Authentication-Results: mail.example.com (amavisd-new);
- =?UTF-8?B?ZGtpbT1wYXNzIGhlYWRlci5pPUBnbWFpbC5jb20=?=
-Dkim-Signature: =?UTF-8?B?dj0xOyBhPXJzYS1zaGEyNTY7IGM9cmVsYXhlZC9yZWxh?=
- =?UTF-8?B?eGVkOyAgICAgICAgZD1nbWFpbC5jb207IHM9MjAxMjAxMTM7ICAgICAgICBo?=
- =?UTF-8?B?PW1pbWUtdmVyc2lvbjp4LWdvb21vamktYm9keTpkYXRlOm1lc3NhZ2UtaWQ6?=
- =?UTF-8?B?c3ViamVjdDpmcm9tOnRvICAgICAgICAgOmNvbnRlbnQtdHlwZTsgICAgICAg?=
- =?UTF-8?B?IGJoPWF4ZGNNUzlWU0lUOS9nOGgvbzY5R0R0YjROMWNZUTJyVU9ydm03LzQ2?=
- =?UTF-8?B?RFU9OyAgICAgICAgYj16dzBpT3JGb3lCMWduL3FpRmRndVhzNE9NN1VCMGQ0?=
- =?UTF-8?B?a1Q2T09CcThKWS8xQlFBbFM5aitpdHFBK25lem9GZzg0YTMgICAgICAgICBP?=
- =?UTF-8?B?TnhibjRteTJSWkx2OVNTS1lSc05yK1NPTVBzRUFqTkpKR29XYWNFNy9KbVc3?=
- =?UTF-8?B?aVZDV3BHQjBjbzdFanhocjNFd1VNMCAgICAgICAgIEcyZlpCNy9jUXJWN3pZ?=
- =?UTF-8?B?SXJra29ldFJXWVRxVHZPdDdXOGxmRUphTFhGT1NBVHFXL1hjYW9zNUJXbzg4?=
- =?UTF-8?B?ckpJbURXcmV3ICAgICAgICAgMWszWWJuTnMwanlYdlBPK2p5dFVmV0VrRFB1?=
- =?UTF-8?B?N3cxaytLOVRxdkh0R2Vhd3lqMjFRZU5tbzFaMVAvL2cyOU1PNjFtL04gICAg?=
- =?UTF-8?B?ICAgICBiVStJZXhkT0cvTzRYY2F1VTFRazhnR20weEEzc3pHWlhHYWFqaThl?=
- =?UTF-8?B?Qmdrblk4RTZieE5JdElpRGFKOXZIR0x2eU1aaiAgICAgICAgIDZTR2c9PQ==?=
+X-Spam-Level: 
+X-Spam-Status: No, score=-1.507 tagged_above=-10 required=6.6
+    tests=[BAYES_00=-1.9, DKIM_SIGNED=0.1, DKIM_VALID=-0.1,
+    DKIM_VALID_AU=-0.1, FREEMAIL_FROM=0.001, HTML_IMAGE_ONLY_04=1.172,
+    HTML_MESSAGE=0.001, RCVD_IN_DNSWL_LOW=-0.7, SPF_PASS=-0.001,
+    T_FREEMAIL_DOC_PDF=0.01, T_TO_NO_BRKTS_FREEMAIL=0.01] autolearn=ham
+Authentication-Results: mail.example.com (amavisd-new); dkim=pass
+    header.i=@gmail.com
+Dkim-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;        d=gmail.com;
+    s=20120113;       
+    h=mime-version:x-goomoji-body:date:message-id:subject:from:to        
+    :content-type;        bh=axdcMS9VSIT9/g8h/o69GDtb4N1cYQ2rUOrvm7/46DU=;    
+       b=zw0iOrFoyB1gn/qiFdguXs4OM7UB0d4kT6OOBq8JY/1BQAlS9j+itqA+nezoFg84a3   
+         ONxbn4my2RZLv9SSKYRsNr+SOMPsEAjNJJGoWacE7/JmW7iVCWpGB0co7Ejxhr3EwUM0 
+          
+    G2fZB7/cQrV7zYIrkkoetRWYTqTvOt7W8lfEJaLXFOSATqW/Xcaos5BWo88rJImDWrew      
+      1k3YbnNs0jyXvPO+jytUfWEkDPu7w1k+K9TqvHtGeawyj21QeNmo1Z1P//g29MO61m/N    
+        bU+IexdOG/O4XcauU1Qk8gGm0xA3szGZXGaaji8eBgknY8E6bxNItIiDaJ9vHGLvyMZj  
+          6SGg==
 X-Goomoji-Body: true
 Date: Thu, 16 Aug 2012 15:45:32 +0100
 Message-Id: <CAJ_TRnL=YMObf2FT9bU7NO0ziPYxpnxfxrtOz4r2-aBxkHSOrA@mail.gmail.com>

--- a/tests/__files/bounce_head-expected-headers.txt
+++ b/tests/__files/bounce_head-expected-headers.txt
@@ -4,8 +4,8 @@ To: bounce-1149-42342-20831917-live@mail.example.com
 MIME-Version: 1.0
 X-Original-To: bounce-1149-42342-20831917-live@mail.example.com
 Delivered-To: bounce@mail.example.com
-Received: from mta65117.example.com (mta65117.example.com [109.68.65.117])
-        by mail.example.com (Postfix) with ESMTP id 413291A0374        for
- <bounce-1149-42342-20831917-live@mail.example.com>; Mon, 20 Aug 2012
- 05:17:28 +0100 (BST)
+Received: from mta65117.example.com (mta65117.example.com [109.68.65.117])    
+       by mail.example.com (Postfix) with ESMTP id 413291A0374        for
+    <bounce-1149-42342-20831917-live@mail.example.com>; Mon, 20 Aug 2012
+    05:17:28 +0100 (BST)
 Date: Mon, 20 Aug 2012 05:15:26 +0100

--- a/tests/__files/bounce_msg-expected-headers.txt
+++ b/tests/__files/bounce_msg-expected-headers.txt
@@ -5,12 +5,12 @@ MIME-Version: 1.0
 X-Original-To: bounce-1149-42363-11284257-live@mail.example.com
 Delivered-To: bounce@mail.example.com
 Received: from smtp1.example.com (smtp2.example.com [205.149.24.12]) by
- mail.example.com (Postfix) with ESMTP id A2E901A0374 for
- <bounce-1149-42363-11284257-live@mail.example.com>; Mon, 20 Aug 2012
- 12:02:25 +0100 (BST)
+    mail.example.com (Postfix) with ESMTP id A2E901A0374 for
+    <bounce-1149-42363-11284257-live@mail.example.com>; Mon, 20 Aug 2012
+    12:02:25 +0100 (BST)
 Received: from uspexhub02.example.com (10.50.51.21) by smtp2.example.com
- (192.168.50.12) with Microsoft SMTP Server (TLS) id 8.3.245.1; Mon, 20 Aug
- 2012 07:02:33 -0400
+    (192.168.50.12) with Microsoft SMTP Server (TLS) id 8.3.245.1; Mon, 20 Aug
+    2012 07:02:33 -0400
 Date: Mon, 20 Aug 2012 07:02:24 -0400
 Content-Language: en-US
 Message-Id: <2b2c1a86-066f-47e6-a318-6a206ce97d78>

--- a/tests/__files/content_attachment-expected-headers.txt
+++ b/tests/__files/content_attachment-expected-headers.txt
@@ -3,7 +3,7 @@ Subject: Welcome NAME HERE
 To: Recipient Name <recipient@example.com>
 Reply-To: Owner <owner@example.com>
 Received: from localhost (track.example.com. [10.1.6.5]) by trx.example.com
- with ESMTP (stage ESMTP Postfix); Wed, 19 Dec 2012 10:26:22 +0000
+    with ESMTP (stage ESMTP Postfix); Wed, 19 Dec 2012 10:26:22 +0000
 Content-Disposition: inline
 Message-Id: <20121219102623.0D45A1620AA@mail.example.com>
 Date: Wed, 19 Dec 2012 10:26:23 +0000 (GMT)

--- a/tests/__files/html-expected-headers.txt
+++ b/tests/__files/html-expected-headers.txt
@@ -5,17 +5,17 @@ Subject: London Olympics: Business Continuity Plan -
 To: recipient@example.com
 Reply-To: Events <eventmarketing@example.com>
 Received: from gbnthda3150srv.example.com ([10.67.121.52]) by
- GBLONVMSX001.nsicorp.int with Microsoft SMTPSVC(6.0.3790.4675);  Thu, 29
- Sep 2011 08:48:51 +0100
-Received: from localhost (unknown [127.0.0.1]) by IMSVA80 (Postfix) with
- SMTP id E307622003E for <recipient@example.com>; Thu, 29 Sep 2011 08:48:58
- +0100 (BST)
+    GBLONVMSX001.nsicorp.int with Microsoft SMTPSVC(6.0.3790.4675);  Thu, 29
+    Sep 2011 08:48:51 +0100
+Received: from localhost (unknown [127.0.0.1]) by IMSVA80 (Postfix) with SMTP
+    id E307622003E for <recipient@example.com>; Thu, 29 Sep 2011 08:48:58
+    +0100 (BST)
 Received: from mta6551.example.com (unknown [109.68.65.51]) by
- gbnthda3150srv.example.com (Postfix) with ESMTP id 6F72A220057 for
- <recipient@example.com>; Fri, 23 Sep 2011 09:54:25 +0100 (BST)
+    gbnthda3150srv.example.com (Postfix) with ESMTP id 6F72A220057 for
+    <recipient@example.com>; Fri, 23 Sep 2011 09:54:25 +0100 (BST)
 Received: by mta6551.example.com (PowerMTA(TM) v3.5r14) id hfh4js0sv5km for
- <recipient@example.com>; Fri, 23 Sep 2011 09:54:22 +0100 (envelope-from
- <bounce-100-250-1831-live@mail.example.com>)
+    <recipient@example.com>; Fri, 23 Sep 2011 09:54:22 +0100 (envelope-from
+    <bounce-100-250-1831-live@mail.example.com>)
 X-Mailer: MXM-v5-MailEngine
 Message-Id: <0.0.24D.2F1.1CC79CE6346CBD8.0@mta6551.example.com>
 Date: Fri, 23 Sep 2011 09:54:22 +0100
@@ -24,29 +24,20 @@ X-Tm-As-Result: No--4.601200-8.000000-31
 X-Imss-Scan-Details: No--12.138-5.0-31-10
 X-Tm-As-User-Approved-Sender: No
 X-Tm-As-Result-Xfilter: Match text exemption rules:No
-X-Tmase-Matchedrid:
- Q2+zkeG6t3p+YGzLN7T7mqGIP6nmLu6LLw30/c3NkEDNcm2bW2t5nPvA
- =?UTF-8?B?RHZUbkNmNXZEWUJWS21iZWVRT1ZJVTkvQ00zMmtkV241OXhuRTBpSG9NZDhm?=
- =?UTF-8?B?ejYwVzVlWXJINSthQTAwRW40V29MVmtpRjVNckRGIHRtZTUzS3Z0REdGdkJl?=
- =?UTF-8?B?QjJuWEVLN2VKUVd0ZlFPR2JOdVNlTnFjTjkyS045MGZHMmlJdWpMUW1Jb1Zu?=
- =?UTF-8?B?T1NHMUN2QWc3Ujh5UkZ4TCBneU1yM3EwYUZJL2hPaEtlMmlmN0ZEWUdweVhx?=
- =?UTF-8?B?M2ltZzk0WDBlZy9vbDF5ekVnclI5TlBHTUN3cVRjcldzc1hKTTgyVXkySmdR?=
- =?UTF-8?B?WUMgY1Fyd2RKZkdTcWRFbWVEL25WRW0yejA0akdvRXcxVWNudUxweFlnVlFx?=
- =?UTF-8?B?Y1N0QktKcjl1TEE2MGFVQ21tRlZCV2dFc1F6dTA5U3p6IGFUQndHVkI1Mklr?=
- =?UTF-8?B?d3lWMUhlUG40bWNYUGduVTEyVUk2TGFpTDFsV1pZWkV6M3piQXludFpDcGZN?=
- =?UTF-8?B?S3k5Zk5MT0VsVzA4VXJiVTNtMiBLb3NjeUN5ejY3RU85NDN6bUpLb1V6UDFH?=
- =?UTF-8?B?ZmJiYlRXV3N0ek9sU3pXOUxGYXk5dTA3Q2J4N3luM0ZNcUlEZjUrVzJZRjRS?=
- =?UTF-8?B?WFlpdzggTDFucllZaCt3OVd6L3hYRHB0UFhSVEhCbFlzQUl4UWtYRHROZTdE?=
- =?UTF-8?B?YTZTL3B1Y21qdGFpS05Uck0zeUcxOUl2WUpPZ3UzQ2hEcUlRIGI3c1FlZU83?=
- =?UTF-8?B?NFpmVHlBUXNMNm56eFNKY3duMFlaUGxpV0d2eWFqTWdLUThCNk1KOWNLanFK?=
- =?UTF-8?B?eHloTXVuS01Maitqc1F5Ty93STVFeiBKRVRUVkNJOVZHdWduZlJPQUNGNVRL?=
- =?UTF-8?B?YWFkMTk1Smt4MGNXVWhlczR5Z1BIZy9DZUJmazhGRDJjZzBqL3RydWJ0OFRr?=
- =?UTF-8?B?TDRaUTdTVS8gUXRpRFNhL2Zpb0o5bDRIaGhWL1hCWnpZVENGOGJhVFZ4OERV?=
- =?UTF-8?B?b0NPVm55dVZWZ2Vyay80eGVhdXVZN3pvN3dNTHl5R2lHSWowekZJIDVEb0pJ?=
- =?UTF-8?B?ODIzRC9vVm8wL1BrM1NqWk1jWkZrSzY1Sm5PMXJvVTNnVDJ6WFlhOS9uZElW?=
- =?UTF-8?B?bkpvbVl3aEdiN0RIRWxHZVhqbEF2SmNjZCBVeTJPKysvNnRvTzNRcjBkb2xu?=
- =?UTF-8?B?R1hIWE5WRzFCNDBRMm1zaHMyZjY4SDI5a05tZHV6eURmWmhSK2hDQ0JYaWgy?=
- =?UTF-8?B?bkxuMDlQcDVFNXAgNHcyQnZFYTViZm5yUnJPa2Q0cG5LSG1Tb2c9PQ==?=
+X-Tmase-Matchedrid: Q2+zkeG6t3p+YGzLN7T7mqGIP6nmLu6LLw30/c3NkEDNcm2bW2t5nPvA
+    DvTnCf5vDYBVKmbeeQOVIU9/CM32kdWn59xnE0iHoMd8fz60W5eYrH5+aA00En4WoLVkiF5MrDF
+    tme53KvtDGFvBeB2nXEK7eJQWtfQOGbNuSeNqcN92KN90fG2iIujLQmIoVnOSG1CvAg7R8yRFxL
+    gyMr3q0aFI/hOhKe2if7FDYGpyXq3img94X0eg/ol1yzEgrR9NPGMCwqTcrWssXJM82Uy2JgQYC
+    cQrwdJfGSqdEmeD/nVEm2z04jGoEw1UcnuLpxYgVQqcStBKJr9uLA60aUCmmFVBWgEsQzu09Szz
+    aTBwGVB52IkwyV1HePn4mcXPgnU12UI6LaiL1lWZYZEz3zbAyntZCpfMKy9fNLOElW08UrbU3m2
+    KoscyCyz67EO943zmJKoUzP1GfbbbTWWstzOlSzW9LFay9u07Cbx7yn3FMqIDf5+W2YF4RXYiw8
+    L1nrYYh+w9Wz/xXDptPXRTHBlYsAIxQkXDtNe7Da6S/pucmjtaiKNTrM3yG19IvYJOgu3ChDqIQ
+    b7sQeeO74ZfTyAQsL6nzxSJcwn0YZPliWGvyajMgKQ8B6MJ9cKjqJxyhMunKMLj+jsQyO/wI5Ez
+    JETTVCI9VGugnfROACF5TKaad195Jkx0cWUhes4ygPHg/CeBfk8FD2cg0j/trubt8TkL4ZQ7SU/
+    QtiDSa/fioJ9l4HhhV/XBZzYTCF8baTVx8DUoCOVnyuVVgerk/4xeauuY7zo7wMLyyGiGIj0zFI
+    5DoJI823D/oVo0/Pk3SjZMcZFkK65JnO1roU3gT2zXYa9/ndIVnJomYwhGb7DHElGeXjlAvJccd
+    Uy2O++/6toO3Qr0dolnGXHXNVG1B40Q2mshs2f68H29kNmduzyDfZhR+hCCBXih2nLn09Pp5E5p
+    4w2BvEa5bfnrRrOkd4pnKHmSog==
 X-Originalarrivaltime: 29 Sep 2011 07:48:51.0471 (UTC)
- =?UTF-8?B?RklMRVRJTUU9WzNBRDBEMUYwOjAxQ0M3RTdDXQ==?=
+    FILETIME=[3AD0D1F0:01CC7E7C]
 X-Tm-As-User-Blocked-Sender: No


### PR DESCRIPTION
Do not encode pure-ASCII headers. Only use RFC2047 encoded-words when non-ASCII characters are detected. Wrap long header values at 78 characters as per RFC5322 2.1.1.

Trim unnecessary header value whitespace.