### PR TITLE
Fix incorrect 4 spaces added to folded headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Incorrectly adding 4 spaces to folded headers. Now only uses 1 as indicated
+ by [RFC5322 §2.2.3](https://tools.ietf.org/html/rfc5322#section-2.2.3).
 
 ## [3.2.0] - 2018-10-08
 ### Changed

--- a/src/AbstractPart.php
+++ b/src/AbstractPart.php
@@ -238,13 +238,13 @@ abstract class AbstractPart
             return $header;
         }
         // Even if content is all ASCII, mb_encode_mimeheader() would encode it if the header length exceeds 78 chars.
-        // wordwrap() doesn't account for the 4 spaces added after the new line-break, so break instead at 74.
+        // wordwrap() doesn't account for the space added after the new line-break, so break instead at 77.
         if (mb_check_encoding($header, 'ASCII') === true) {
             if (strlen($header) <= 78) {
                 return $header;
             }
-            return substr($header, 0, 4) .
-                wordwrap(substr($header, 4), 74, "\r\n    ", false);
+            return substr($header, 0, 1) .
+                wordwrap(substr($header, 1), 77, "\r\n ", false);
         }
         $charset = $this->charset;
         if (!$charset) {

--- a/tests/AbstractPartTest.php
+++ b/tests/AbstractPartTest.php
@@ -225,7 +225,7 @@ class AbstractPartTest extends TestCase
     {
         $this->part->addHeader($name, implode(' ', $valueParts));
 
-        $expected = "$name: " . implode("\r\n    ", $valueParts) . "\r\n";
+        $expected = "$name: " . implode("\r\n ", $valueParts) . "\r\n";
 
         $actual = $this->part->getEncodedHeaders();
         $this->assertEquals($expected, $actual);

--- a/tests/__files/attachments-expected-headers.txt
+++ b/tests/__files/attachments-expected-headers.txt
@@ -4,43 +4,42 @@ Subject: Attachments
 To: recipient@example.com
 MIME-Version: 1.0
 Received: from mail.example.com (LHLO mail.example.com) (10.1.9.1) by
-    mail.example.com with LMTP; Thu, 16 Aug 2012 15:45:43 +0100 (BST)
+ mail.example.com with LMTP; Thu, 16 Aug 2012 15:45:43 +0100 (BST)
 Received: from localhost (localhost [127.0.0.1]) by mail.example.com (Postfix)
-    with ESMTP id ED35D161D86 for <recipient@example.com>; Thu, 16 Aug 2012
-    15:45:43 +0100 (BST)
+ with ESMTP id ED35D161D86 for <recipient@example.com>; Thu, 16 Aug 2012
+ 15:45:43 +0100 (BST)
 Received: from mail.example.com ([127.0.0.1]) by localhost (mail.example.com
-    [127.0.0.1]) (amavisd-new, port 10024) with ESMTP id x9xbo4ZNbRu7 for
-    <recipient@example.com>; Thu, 16 Aug 2012 15:45:42 +0100 (BST)
+ [127.0.0.1]) (amavisd-new, port 10024) with ESMTP id x9xbo4ZNbRu7 for
+ <recipient@example.com>; Thu, 16 Aug 2012 15:45:42 +0100 (BST)
 Received: from mail-yx0-f181.google.com (mail-yx0-f181.google.com
-    [209.85.213.181]) by mail.example.com (Postfix) with ESMTPS id 92F4A161D85
-    for <recipient@example.com>; Thu, 16 Aug 2012 15:45:41 +0100 (BST)
+ [209.85.213.181]) by mail.example.com (Postfix) with ESMTPS id 92F4A161D85
+ for <recipient@example.com>; Thu, 16 Aug 2012 15:45:41 +0100 (BST)
 Received: by yenq13 with SMTP id q13so3462367yen.40        for
-    <recipient@example.com>; Thu, 16 Aug 2012 07:45:40 -0700 (PDT)
+ <recipient@example.com>; Thu, 16 Aug 2012 07:45:40 -0700 (PDT)
 Received: by 10.50.76.202 with SMTP id m10mr1877022igw.52.1345128339903; Thu,
-    16 Aug 2012 07:45:39 -0700 (PDT)
+ 16 Aug 2012 07:45:39 -0700 (PDT)
 Received: by 10.64.82.163 with HTTP; Thu, 16 Aug 2012 07:45:32 -0700 (PDT)
 X-Virus-Scanned: amavisd-new at example.com
 X-Spam-Flag: NO
 X-Spam-Score: -1.507
 X-Spam-Level: 
 X-Spam-Status: No, score=-1.507 tagged_above=-10 required=6.6
-    tests=[BAYES_00=-1.9, DKIM_SIGNED=0.1, DKIM_VALID=-0.1,
-    DKIM_VALID_AU=-0.1, FREEMAIL_FROM=0.001, HTML_IMAGE_ONLY_04=1.172,
-    HTML_MESSAGE=0.001, RCVD_IN_DNSWL_LOW=-0.7, SPF_PASS=-0.001,
-    T_FREEMAIL_DOC_PDF=0.01, T_TO_NO_BRKTS_FREEMAIL=0.01] autolearn=ham
+ tests=[BAYES_00=-1.9, DKIM_SIGNED=0.1, DKIM_VALID=-0.1, DKIM_VALID_AU=-0.1,
+ FREEMAIL_FROM=0.001, HTML_IMAGE_ONLY_04=1.172, HTML_MESSAGE=0.001,
+ RCVD_IN_DNSWL_LOW=-0.7, SPF_PASS=-0.001, T_FREEMAIL_DOC_PDF=0.01,
+ T_TO_NO_BRKTS_FREEMAIL=0.01] autolearn=ham
 Authentication-Results: mail.example.com (amavisd-new); dkim=pass
-    header.i=@gmail.com
+ header.i=@gmail.com
 Dkim-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;        d=gmail.com;
-    s=20120113;       
-    h=mime-version:x-goomoji-body:date:message-id:subject:from:to        
-    :content-type;        bh=axdcMS9VSIT9/g8h/o69GDtb4N1cYQ2rUOrvm7/46DU=;    
-       b=zw0iOrFoyB1gn/qiFdguXs4OM7UB0d4kT6OOBq8JY/1BQAlS9j+itqA+nezoFg84a3   
-         ONxbn4my2RZLv9SSKYRsNr+SOMPsEAjNJJGoWacE7/JmW7iVCWpGB0co7Ejxhr3EwUM0 
-          
-    G2fZB7/cQrV7zYIrkkoetRWYTqTvOt7W8lfEJaLXFOSATqW/Xcaos5BWo88rJImDWrew      
-      1k3YbnNs0jyXvPO+jytUfWEkDPu7w1k+K9TqvHtGeawyj21QeNmo1Z1P//g29MO61m/N    
-        bU+IexdOG/O4XcauU1Qk8gGm0xA3szGZXGaaji8eBgknY8E6bxNItIiDaJ9vHGLvyMZj  
-          6SGg==
+ s=20120113;       
+ h=mime-version:x-goomoji-body:date:message-id:subject:from:to        
+ :content-type;        bh=axdcMS9VSIT9/g8h/o69GDtb4N1cYQ2rUOrvm7/46DU=;       
+ b=zw0iOrFoyB1gn/qiFdguXs4OM7UB0d4kT6OOBq8JY/1BQAlS9j+itqA+nezoFg84a3        
+ ONxbn4my2RZLv9SSKYRsNr+SOMPsEAjNJJGoWacE7/JmW7iVCWpGB0co7Ejxhr3EwUM0        
+ G2fZB7/cQrV7zYIrkkoetRWYTqTvOt7W8lfEJaLXFOSATqW/Xcaos5BWo88rJImDWrew        
+ 1k3YbnNs0jyXvPO+jytUfWEkDPu7w1k+K9TqvHtGeawyj21QeNmo1Z1P//g29MO61m/N        
+ bU+IexdOG/O4XcauU1Qk8gGm0xA3szGZXGaaji8eBgknY8E6bxNItIiDaJ9vHGLvyMZj        
+ 6SGg==
 X-Goomoji-Body: true
 Date: Thu, 16 Aug 2012 15:45:32 +0100
 Message-Id: <CAJ_TRnL=YMObf2FT9bU7NO0ziPYxpnxfxrtOz4r2-aBxkHSOrA@mail.gmail.com>

--- a/tests/__files/bounce_head-expected-headers.txt
+++ b/tests/__files/bounce_head-expected-headers.txt
@@ -5,7 +5,7 @@ MIME-Version: 1.0
 X-Original-To: bounce-1149-42342-20831917-live@mail.example.com
 Delivered-To: bounce@mail.example.com
 Received: from mta65117.example.com (mta65117.example.com [109.68.65.117])    
-       by mail.example.com (Postfix) with ESMTP id 413291A0374        for
-    <bounce-1149-42342-20831917-live@mail.example.com>; Mon, 20 Aug 2012
-    05:17:28 +0100 (BST)
+    by mail.example.com (Postfix) with ESMTP id 413291A0374        for
+ <bounce-1149-42342-20831917-live@mail.example.com>; Mon, 20 Aug 2012 05:17:28
+ +0100 (BST)
 Date: Mon, 20 Aug 2012 05:15:26 +0100

--- a/tests/__files/bounce_msg-expected-headers.txt
+++ b/tests/__files/bounce_msg-expected-headers.txt
@@ -5,12 +5,12 @@ MIME-Version: 1.0
 X-Original-To: bounce-1149-42363-11284257-live@mail.example.com
 Delivered-To: bounce@mail.example.com
 Received: from smtp1.example.com (smtp2.example.com [205.149.24.12]) by
-    mail.example.com (Postfix) with ESMTP id A2E901A0374 for
-    <bounce-1149-42363-11284257-live@mail.example.com>; Mon, 20 Aug 2012
-    12:02:25 +0100 (BST)
+ mail.example.com (Postfix) with ESMTP id A2E901A0374 for
+ <bounce-1149-42363-11284257-live@mail.example.com>; Mon, 20 Aug 2012 12:02:25
+ +0100 (BST)
 Received: from uspexhub02.example.com (10.50.51.21) by smtp2.example.com
-    (192.168.50.12) with Microsoft SMTP Server (TLS) id 8.3.245.1; Mon, 20 Aug
-    2012 07:02:33 -0400
+ (192.168.50.12) with Microsoft SMTP Server (TLS) id 8.3.245.1; Mon, 20 Aug
+ 2012 07:02:33 -0400
 Date: Mon, 20 Aug 2012 07:02:24 -0400
 Content-Language: en-US
 Message-Id: <2b2c1a86-066f-47e6-a318-6a206ce97d78>

--- a/tests/__files/content_attachment-expected-headers.txt
+++ b/tests/__files/content_attachment-expected-headers.txt
@@ -3,7 +3,7 @@ Subject: Welcome NAME HERE
 To: Recipient Name <recipient@example.com>
 Reply-To: Owner <owner@example.com>
 Received: from localhost (track.example.com. [10.1.6.5]) by trx.example.com
-    with ESMTP (stage ESMTP Postfix); Wed, 19 Dec 2012 10:26:22 +0000
+ with ESMTP (stage ESMTP Postfix); Wed, 19 Dec 2012 10:26:22 +0000
 Content-Disposition: inline
 Message-Id: <20121219102623.0D45A1620AA@mail.example.com>
 Date: Wed, 19 Dec 2012 10:26:23 +0000 (GMT)

--- a/tests/__files/html-expected-headers.txt
+++ b/tests/__files/html-expected-headers.txt
@@ -5,17 +5,17 @@ Subject: London Olympics: Business Continuity Plan -
 To: recipient@example.com
 Reply-To: Events <eventmarketing@example.com>
 Received: from gbnthda3150srv.example.com ([10.67.121.52]) by
-    GBLONVMSX001.nsicorp.int with Microsoft SMTPSVC(6.0.3790.4675);  Thu, 29
-    Sep 2011 08:48:51 +0100
+ GBLONVMSX001.nsicorp.int with Microsoft SMTPSVC(6.0.3790.4675);  Thu, 29 Sep
+ 2011 08:48:51 +0100
 Received: from localhost (unknown [127.0.0.1]) by IMSVA80 (Postfix) with SMTP
-    id E307622003E for <recipient@example.com>; Thu, 29 Sep 2011 08:48:58
-    +0100 (BST)
+ id E307622003E for <recipient@example.com>; Thu, 29 Sep 2011 08:48:58 +0100
+ (BST)
 Received: from mta6551.example.com (unknown [109.68.65.51]) by
-    gbnthda3150srv.example.com (Postfix) with ESMTP id 6F72A220057 for
-    <recipient@example.com>; Fri, 23 Sep 2011 09:54:25 +0100 (BST)
+ gbnthda3150srv.example.com (Postfix) with ESMTP id 6F72A220057 for
+ <recipient@example.com>; Fri, 23 Sep 2011 09:54:25 +0100 (BST)
 Received: by mta6551.example.com (PowerMTA(TM) v3.5r14) id hfh4js0sv5km for
-    <recipient@example.com>; Fri, 23 Sep 2011 09:54:22 +0100 (envelope-from
-    <bounce-100-250-1831-live@mail.example.com>)
+ <recipient@example.com>; Fri, 23 Sep 2011 09:54:22 +0100 (envelope-from
+ <bounce-100-250-1831-live@mail.example.com>)
 X-Mailer: MXM-v5-MailEngine
 Message-Id: <0.0.24D.2F1.1CC79CE6346CBD8.0@mta6551.example.com>
 Date: Fri, 23 Sep 2011 09:54:22 +0100
@@ -25,19 +25,19 @@ X-Imss-Scan-Details: No--12.138-5.0-31-10
 X-Tm-As-User-Approved-Sender: No
 X-Tm-As-Result-Xfilter: Match text exemption rules:No
 X-Tmase-Matchedrid: Q2+zkeG6t3p+YGzLN7T7mqGIP6nmLu6LLw30/c3NkEDNcm2bW2t5nPvA
-    DvTnCf5vDYBVKmbeeQOVIU9/CM32kdWn59xnE0iHoMd8fz60W5eYrH5+aA00En4WoLVkiF5MrDF
-    tme53KvtDGFvBeB2nXEK7eJQWtfQOGbNuSeNqcN92KN90fG2iIujLQmIoVnOSG1CvAg7R8yRFxL
-    gyMr3q0aFI/hOhKe2if7FDYGpyXq3img94X0eg/ol1yzEgrR9NPGMCwqTcrWssXJM82Uy2JgQYC
-    cQrwdJfGSqdEmeD/nVEm2z04jGoEw1UcnuLpxYgVQqcStBKJr9uLA60aUCmmFVBWgEsQzu09Szz
-    aTBwGVB52IkwyV1HePn4mcXPgnU12UI6LaiL1lWZYZEz3zbAyntZCpfMKy9fNLOElW08UrbU3m2
-    KoscyCyz67EO943zmJKoUzP1GfbbbTWWstzOlSzW9LFay9u07Cbx7yn3FMqIDf5+W2YF4RXYiw8
-    L1nrYYh+w9Wz/xXDptPXRTHBlYsAIxQkXDtNe7Da6S/pucmjtaiKNTrM3yG19IvYJOgu3ChDqIQ
-    b7sQeeO74ZfTyAQsL6nzxSJcwn0YZPliWGvyajMgKQ8B6MJ9cKjqJxyhMunKMLj+jsQyO/wI5Ez
-    JETTVCI9VGugnfROACF5TKaad195Jkx0cWUhes4ygPHg/CeBfk8FD2cg0j/trubt8TkL4ZQ7SU/
-    QtiDSa/fioJ9l4HhhV/XBZzYTCF8baTVx8DUoCOVnyuVVgerk/4xeauuY7zo7wMLyyGiGIj0zFI
-    5DoJI823D/oVo0/Pk3SjZMcZFkK65JnO1roU3gT2zXYa9/ndIVnJomYwhGb7DHElGeXjlAvJccd
-    Uy2O++/6toO3Qr0dolnGXHXNVG1B40Q2mshs2f68H29kNmduzyDfZhR+hCCBXih2nLn09Pp5E5p
-    4w2BvEa5bfnrRrOkd4pnKHmSog==
+ DvTnCf5vDYBVKmbeeQOVIU9/CM32kdWn59xnE0iHoMd8fz60W5eYrH5+aA00En4WoLVkiF5MrDF
+ tme53KvtDGFvBeB2nXEK7eJQWtfQOGbNuSeNqcN92KN90fG2iIujLQmIoVnOSG1CvAg7R8yRFxL
+ gyMr3q0aFI/hOhKe2if7FDYGpyXq3img94X0eg/ol1yzEgrR9NPGMCwqTcrWssXJM82Uy2JgQYC
+ cQrwdJfGSqdEmeD/nVEm2z04jGoEw1UcnuLpxYgVQqcStBKJr9uLA60aUCmmFVBWgEsQzu09Szz
+ aTBwGVB52IkwyV1HePn4mcXPgnU12UI6LaiL1lWZYZEz3zbAyntZCpfMKy9fNLOElW08UrbU3m2
+ KoscyCyz67EO943zmJKoUzP1GfbbbTWWstzOlSzW9LFay9u07Cbx7yn3FMqIDf5+W2YF4RXYiw8
+ L1nrYYh+w9Wz/xXDptPXRTHBlYsAIxQkXDtNe7Da6S/pucmjtaiKNTrM3yG19IvYJOgu3ChDqIQ
+ b7sQeeO74ZfTyAQsL6nzxSJcwn0YZPliWGvyajMgKQ8B6MJ9cKjqJxyhMunKMLj+jsQyO/wI5Ez
+ JETTVCI9VGugnfROACF5TKaad195Jkx0cWUhes4ygPHg/CeBfk8FD2cg0j/trubt8TkL4ZQ7SU/
+ QtiDSa/fioJ9l4HhhV/XBZzYTCF8baTVx8DUoCOVnyuVVgerk/4xeauuY7zo7wMLyyGiGIj0zFI
+ 5DoJI823D/oVo0/Pk3SjZMcZFkK65JnO1roU3gT2zXYa9/ndIVnJomYwhGb7DHElGeXjlAvJccd
+ Uy2O++/6toO3Qr0dolnGXHXNVG1B40Q2mshs2f68H29kNmduzyDfZhR+hCCBXih2nLn09Pp5E5p
+ 4w2BvEa5bfnrRrOkd4pnKHmSog==
 X-Originalarrivaltime: 29 Sep 2011 07:48:51.0471 (UTC)
-    FILETIME=[3AD0D1F0:01CC7E7C]
+ FILETIME=[3AD0D1F0:01CC7E7C]
 X-Tm-As-User-Blocked-Sender: No


### PR DESCRIPTION
Fix incorrect 4 spaces added to folded headers to only uses 1.
See [RFC5322 §2.2.3](https://tools.ietf.org/html/rfc5322#section-2.2.3).

The DKIm signature in `tests/__files/attachments-expected-headers.txt` looks more realistic now!

To release as new patch version.