### PR TITLE
Use Symfony/Mime to encode Mail headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- *symfony/mime* added as a required dependency.
+### Fixed
+- Encoding full mailbox header when Display Name contains extended characters.
+  Now only encode the affected part of the Display Name, so the address stays
+  compliant with Address Specification
+  [RFC5322 §3.4](https://tools.ietf.org/html/rfc5322#section-3.4).
 
 ## [3.2.1] - 2019-07-30
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   Now only encode the affected part of the Display Name, so the address stays
   compliant with Address Specification
   [RFC5322 §3.4](https://tools.ietf.org/html/rfc5322#section-3.4).
+### Removed
+- **BC break**: Removed `Mail::formatAddress()`
 
 ## [3.2.1] - 2019-07-30
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,10 @@
         "php": "^7.1",
         "ext-fileinfo": "*",
         "ext-mailparse" : "*",
-        "ext-mbstring": "*"
+        "ext-mbstring": "*",
+
+        "egulias/email-validator": "^2",
+        "symfony/mime": "v4.4.0-RC1"
     },
     "require-dev": {
         "ext-iconv" : "*",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "ext-mbstring": "*",
 
         "egulias/email-validator": "^2",
-        "symfony/mime": "v4.4.0-RC1"
+        "symfony/mime": "^4.4"
     },
     "require-dev": {
         "ext-iconv" : "*",

--- a/src/Mail.php
+++ b/src/Mail.php
@@ -289,19 +289,6 @@ class Mail extends AbstractPart
         return $this->subject;
     }
 
-    public function formatAddress(string $address, ?string $name = null): string
-    {
-        if (!$name) {
-            return $address;
-        }
-
-        if (strpos($name, ',') !== false) {
-            return "\"$name\" <$address>";
-        } else {
-            return "$name <$address>";
-        }
-    }
-
     public function hasAttachment(): bool
     {
         return ($this->attachmentCount > 0);

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -293,18 +293,6 @@ class MailTest extends TestCase
         $this->mail->setFrom('invalid address');
     }
 
-    public function testFilterName()
-    {
-        $address = 'dummy@example.com';
-        $name = "\r\n\t\"<>'[]";
-        $expected = [
-            $address => "'[]'[]"
-        ];
-        $this->mail->addTo($address, $name);
-
-        $this->assertEquals($expected, $this->mail->getTo());
-    }
-
     public function testSetGetSubject()
     {
         $subject = 'subject line';

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -406,7 +406,7 @@ class MailTest extends TestCase
     {
         $this->mail->setReturnPath('return-path@example.com');
         $this->mail->setFrom('from@example.com', "From Alias \xf0\x9f\x93\xa7 envelope");
-        $this->mail->setSubject('subject line');
+        $this->mail->setSubject("subject line with \xf0\x9f\x93\xa7 envelope");
         $this->mail->addTo('to+1@example.com', "To Alias 1 \xf0\x9f\x93\xa7 envelope");
         $this->mail->addTo('to+2@example.com', "To Alias 2 \xf0\x9f\x93\xa7 envelope");
         $this->mail->addCc('cc@example.com');
@@ -415,8 +415,8 @@ class MailTest extends TestCase
         $expected = [
             "Return-Path" => '<return-path@example.com>',
             "From" => "From Alias \xf0\x9f\x93\xa7 envelope <from@example.com>",
-            "Subject" => 'subject line',
-            "To" => "To Alias 1 \xf0\x9f\x93\xa7 envelope <to+1@example.com>,\r\n" .
+            "Subject" => "subject line with \xf0\x9f\x93\xa7 envelope",
+            "To" => "To Alias 1 \xf0\x9f\x93\xa7 envelope <to+1@example.com>," .
                 " To Alias 2 \xf0\x9f\x93\xa7 envelope <to+2@example.com>",
             "Cc" => 'cc@example.com',
             "Reply-To" => 'reply-to@example.com'

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -301,32 +301,6 @@ class MailTest extends TestCase
         $this->assertEquals($subject, $this->mail->getSubject());
     }
 
-    /**
-     * @covers \Phlib\Mail\Mail
-     */
-    public function testFormatAddress()
-    {
-        $address = 'dummy@example.com';
-        $name = 'Address Alias';
-        $expected = "{$name} <{$address}>";
-        $actual = $this->mail->formatAddress($address, $name);
-
-        $this->assertEquals($expected, $actual);
-    }
-
-    /**
-     * @covers \Phlib\Mail\Mail
-     */
-    public function testFormatAddressEscaped()
-    {
-        $address = 'dummy@example.com';
-        $name = 'Address,Alias';
-        $expected = "\"{$name}\" <{$address}>";
-        $actual = $this->mail->formatAddress($address, $name);
-
-        $this->assertEquals($expected, $actual);
-    }
-
     public function testHasAttachmentFalse()
     {
         $this->assertEquals(false, $this->mail->hasAttachment());

--- a/tests/__files/html-expected-headers.txt
+++ b/tests/__files/html-expected-headers.txt
@@ -1,7 +1,7 @@
 Return-Path: <bounce-100-250-1831-live@mail.example.com>
 From: Events <eventmarketing@example.com>
-Subject: London Olympics: Business Continuity Plan -
- =?UTF-8?B?wqMxMDAgZGlzY291bnQgdG9kYXkgb25seSE=?=
+Subject: London Olympics: Business Continuity Plan - =?UTF-8?Q?=C2=A3100?=
+ discount today only!
 To: recipient@example.com
 Reply-To: Events <eventmarketing@example.com>
 Received: from gbnthda3150srv.example.com ([10.67.121.52]) by


### PR DESCRIPTION
Fixes #27 

## Changes

* Tests added for cases described in the issue
* Use [symfony/mime](https://github.com/symfony/mime) to encode primary Mail headers
* Existing tests still pass, with one exception where the subject line is now encoded more conservatively
* Remove a method which was used internally for formatting address headers. This was a public method, although it had no need to be.

## Major vs. Minor

As they stand, these changes would require a major version, due to the BC break by removing a public method.

An alternative approach would be to leave out the removal of the public method (as it's no longer used internally, there's no harm to leave it), however I considered that the addition of this package's first external dependency would also require a new major version, so I've included both changes.

If this PR is merged, I'd also like to look at refactoring all the header-building code to use Symfony Mime, using its `Headers` object internally to manage the headers. This doesn't provide all the same functionality we currently have (eg. removing a single header value in the case there are multiple values for a single header name) so would again require a major version.

## Stability

~Finally, these changes aren't currently ready for a stable version release, as they are using Symfony/Mime v4.4 RC1. The package was marked _experimental_ in Symfony v4.3, so there are breaking changes which affect this implementation in v4.4. As it's now at RC stage, further changes aren't expected, and so this should just require one further commit to update the version in composer to `^4.4`. I wanted to create the PR to allow review of the general direction and the major vs. minor issue above. v4.4 is scheduled for release in November 2019.~

EDIT: Symfony/Mime v4.4 has been released today. This has now been updated within this PR. (v5.0 also released, but drops support for PHP 7.1 which this package still supports)