### PR TITLE
Add missing tests

### DIFF
--- a/tests/AbstractPartTest.php
+++ b/tests/AbstractPartTest.php
@@ -282,16 +282,17 @@ class AbstractPartTest extends TestCase
     /**
      * @dataProvider dataSetGetEncodingInvalid
      */
-    public function testSetGetEncodingInvalid($encoding)
+    public function testSetGetEncodingInvalid(string $encoding): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->part->setEncoding($encoding);
     }
 
-    public function dataSetGetEncodingInvalid()
+    public function dataSetGetEncodingInvalid(): iterable
     {
         return [
-            ['invalid-encoding']
+            ['invalid-encoding'],
+            [''],
         ];
     }
 

--- a/tests/AbstractPartTest.php
+++ b/tests/AbstractPartTest.php
@@ -260,6 +260,102 @@ class AbstractPartTest extends TestCase
     }
 
     /**
+     * Special handling for Content-Type, adds charset, encoding and additional params if available
+     * @dataProvider dataGetEncodedHeadersContentType
+     */
+    public function testGetEncodedHeadersContentType(
+        ?string $type,
+        ?string $charset,
+        string $encoding,
+        ?string $typeParam,
+        string $expected
+    ): void {
+        // Use anon class to set the immutable type and add additional params
+        $part = new class ($type, $typeParam) extends AbstractPart {
+            private $typeParam;
+            public function __construct(?string $type, ?string $typeParam)
+            {
+                $this->type = $type;
+                $this->typeParam = $typeParam;
+            }
+            public function toString(): string
+            {
+                return '';
+            }
+            protected function addContentTypeParameters(string $contentType): string
+            {
+                if ($this->typeParam) {
+                    $contentType .= "; {$this->typeParam}";
+                }
+                return $contentType;
+            }
+        };
+
+        if ($charset) {
+            $part->setCharset($charset);
+        }
+        if ($encoding) {
+            $part->setEncoding($encoding);
+        }
+
+        $actual = $part->getEncodedHeaders();
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function dataGetEncodedHeadersContentType(): iterable
+    {
+        $types = [
+            null,
+            'text/html',
+            'application/octet-stream',
+        ];
+        $charsets = [
+            null,
+            'UTF-8',
+            'ascii',
+        ];
+        $encodings = [
+            // Encoding must be allowed type, `null` not allowed
+            AbstractPart::ENCODING_QPRINTABLE,
+            AbstractPart::ENCODING_BASE64,
+        ];
+        $typeParams = [
+            null,
+            'attr=value',
+        ];
+
+        foreach ($types as $type) {
+            foreach ($charsets as $charset) {
+                foreach ($encodings as $encoding) {
+                    foreach ($typeParams as $typeParam) {
+                        $name = ($type ?? 'NULL') . ' ' .
+                            ($charset ?? 'NULL') . ' ' .
+                            ($encoding ?? 'NULL') . ' ' .
+                            ($typeParam ?? 'NULL');
+                        $expected = '';
+                        if ($type !== null) {
+                            $expected = "Content-Type: {$type}";
+
+                            if ($charset !== null) {
+                                $expected .= "; charset=\"{$charset}\"";
+                            }
+                            if ($typeParam !== null) {
+                                $expected .= "; {$typeParam}";
+                            }
+                            $expected .= "\r\n";
+
+                            if ($encoding !== null) {
+                                $expected .= "Content-Transfer-Encoding: {$encoding}\r\n";
+                            }
+                        }
+                        yield $name => [$type, $charset, $encoding, $typeParam, $expected];
+                    }
+                }
+            }
+        }
+    }
+
+    /**
      * @dataProvider dataSetGetEncodingValid
      */
     public function testSetGetEncodingValid($encoding)


### PR DESCRIPTION
Looking at CodeCov, there were a couple of cases which were not covered in testing. These new tests bring coverage to 100% for the core _Part_ classes.

* Adding the `Content-Type` header can be quite complicated, as it relies on 3 different properties and the implementation of a method in child classes. This is now covered with a data provider which tests all the different combinations.
* When creating the MIME boundary string, it's checked to make sure it's unique in the child content and regenerated if necessary. The new test ensures that this behaviour works repetitively.