### PR TITLE
Add tests to verify Mail header defaults

### DIFF
--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -110,6 +110,11 @@ class MailTest extends TestCase
         $this->assertEquals($expectedAfter, $this->mail->getTo());
     }
 
+    public function testGetToDefault(): void
+    {
+        $this->assertSame([], $this->mail->getTo());
+    }
+
     public function testAddGetCc()
     {
         $data = [
@@ -140,6 +145,11 @@ class MailTest extends TestCase
         $this->assertEquals($expectedAfter, $this->mail->getCc());
     }
 
+    public function testGetCcDefault(): void
+    {
+        $this->assertSame([], $this->mail->getCc());
+    }
+
     public function testSetGetReplyTo()
     {
         $data = [
@@ -155,6 +165,11 @@ class MailTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->mail->setReplyTo('invalid address');
+    }
+
+    public function testGetReplyToDefault(): void
+    {
+        $this->assertSame(null, $this->mail->getReplyTo());
     }
 
     public function testSetGetReturnPath()
@@ -181,6 +196,11 @@ class MailTest extends TestCase
         $this->assertEquals(null, $this->mail->getReturnPath());
     }
 
+    public function testGetReturnPathDefault(): void
+    {
+        $this->assertSame(null, $this->mail->getReturnPath());
+    }
+
     public function testSetGetFrom()
     {
         $data = [
@@ -196,6 +216,11 @@ class MailTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->mail->setFrom('invalid address');
+    }
+
+    public function testGetFromDefault(): void
+    {
+        $this->assertSame(null, $this->mail->getFrom());
     }
 
     public function testFilterName()
@@ -216,6 +241,11 @@ class MailTest extends TestCase
         $this->mail->setSubject($subject);
 
         $this->assertEquals($subject, $this->mail->getSubject());
+    }
+
+    public function testGetSubjectDefault(): void
+    {
+        $this->assertSame(null, $this->mail->getSubject());
     }
 
     /**


### PR DESCRIPTION
I noticed once the new Symfony/Mime changes were merged, there weren't any tests covering the new logic to return default values. (See red lines in [this CodeCov report](https://codecov.io/gh/phlib/mail/src/a36edbde088bfff489d6048a75e41cc4fd959a11/src/Mail.php))

This branch is taken before those changes were merged, adding tests for the default values for To, Cc, From, etc.

The branch conflicts because it adds tests where the Symfony/Mime changes took some others away, but I wanted to create the branch from that point to prove the tests worked before and after the Symfony/Mime changes. Once this tests OK in Travis, I can merge master to this branch to resolve the conflicts, and show the tests still pass.