### PR TITLE
Remove PHP v7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: php
 
 php:
-- 7.1
-- 7.2
 - 7.3
+- 7.4snapshot
+
+jobs:
+  allow_failures:
+  - php: 7.4snapshot
 
 before_script:
   - pecl channel-update pecl.php.net

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   compliant with Address Specification
   [RFC5322 §3.4](https://tools.ietf.org/html/rfc5322#section-3.4).
 ### Removed
+- **BC break**: Removed support for PHP v7.1 and v7.2 as they are no longer
+[actively supported](https://php.net/supported-versions.php) by the PHP project
 - **BC break**: Removed `Mail::formatAddress()`
 
 ## [3.2.1] - 2019-07-30

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "ext-mbstring": "*",
 
         "egulias/email-validator": "^2",
-        "symfony/mime": "^4.4"
+        "symfony/mime": "^5"
     },
     "require-dev": {
         "ext-iconv" : "*",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "require-dev": {
         "ext-iconv" : "*",
-        "phpunit/phpunit": "^7",
+        "phpunit/phpunit": "^8",
         "php-mock/php-mock-phpunit": "^2"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.3",
         "ext-fileinfo": "*",
         "ext-mailparse" : "*",
         "ext-mbstring": "*",

--- a/src/AbstractPart.php
+++ b/src/AbstractPart.php
@@ -8,10 +8,10 @@ use Phlib\Mail\Exception\InvalidArgumentException;
 
 abstract class AbstractPart
 {
-    const ENCODING_BASE64     = 'base64';
-    const ENCODING_QPRINTABLE = 'quoted-printable';
-    const ENCODING_7BIT       = '7bit';
-    const ENCODING_8BIT       = '8bit';
+    public const ENCODING_BASE64     = 'base64';
+    public const ENCODING_QPRINTABLE = 'quoted-printable';
+    public const ENCODING_7BIT       = '7bit';
+    public const ENCODING_8BIT       = '8bit';
 
     /**
      * @var array

--- a/src/AbstractPart.php
+++ b/src/AbstractPart.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail;

--- a/src/Content/AbstractContent.php
+++ b/src/Content/AbstractContent.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Content;

--- a/src/Content/Attachment.php
+++ b/src/Content/Attachment.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Content;

--- a/src/Content/Content.php
+++ b/src/Content/Content.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Content;

--- a/src/Content/Html.php
+++ b/src/Content/Html.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Content;

--- a/src/Content/Text.php
+++ b/src/Content/Text.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Content;

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Exception;

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Exception;

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Exception;

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -222,7 +222,8 @@ class Factory
     private function parsePart(string $name, Mail $mail): AbstractPart
     {
         // Get part resource
-        if (($part     = @mailparse_msg_get_part($this->mimeMail, $name)) === false ||
+        if (
+            ($part     = @mailparse_msg_get_part($this->mimeMail, $name)) === false ||
             ($partData = @mailparse_msg_get_part_data($part)) === false
         ) {
             $error = error_get_last();
@@ -241,7 +242,7 @@ class Factory
                     $mailPart = new Mime\MultipartAlternative();
                     break;
                 case 'multipart/mixed':
-                    $mailPart = new Mime\MultipartMixed;
+                    $mailPart = new Mime\MultipartMixed();
                     break;
                 case 'multipart/related':
                     $mailPart = new Mime\MultipartRelated();

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail;

--- a/src/Mail.php
+++ b/src/Mail.php
@@ -320,8 +320,9 @@ class Mail extends AbstractPart
         if (substr($result, -1) !== "\n") {
             // If mail doesn't end with a newline, then append one
             //
-            // This is mostly to get around an issue when parsing the mail string back in through the Factory, as mailparse
-            // cuts off the last line of the email body if it doesn't end with a newline (https://bugs.php.net/bug.php?id=75923)
+            // This is mostly to get around an issue when parsing the mail string back in through the Factory,
+            // as mailparse cuts off the last line of the email body if it doesn't end with a newline
+            // (https://bugs.php.net/bug.php?id=75923)
             //
             // A known issue with this, however, is that a mail with only a content part which is successively
             // parsed->output->parsed->output will keep gaining new lines each time

--- a/src/Mail.php
+++ b/src/Mail.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail;

--- a/src/Mime/AbstractMime.php
+++ b/src/Mime/AbstractMime.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Mime;

--- a/src/Mime/Mime.php
+++ b/src/Mime/Mime.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Mime;

--- a/src/Mime/MultipartAlternative.php
+++ b/src/Mime/MultipartAlternative.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Mime;

--- a/src/Mime/MultipartMixed.php
+++ b/src/Mime/MultipartMixed.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Mime;

--- a/src/Mime/MultipartRelated.php
+++ b/src/Mime/MultipartRelated.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Mime;

--- a/src/Mime/MultipartReport.php
+++ b/src/Mime/MultipartReport.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Mime;

--- a/tests/AbstractPartTest.php
+++ b/tests/AbstractPartTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Tests;

--- a/tests/AbstractPartTest.php
+++ b/tests/AbstractPartTest.php
@@ -14,7 +14,7 @@ class AbstractPartTest extends TestCase
      */
     protected $part;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->part = $this->getMockForAbstractClass(AbstractPart::class);
     }

--- a/tests/AssertAttachmentsEmail.php
+++ b/tests/AssertAttachmentsEmail.php
@@ -119,14 +119,14 @@ class AssertAttachmentsEmail
                     $contentType .= " charset=\"{$details['charset']}\";";
                 }
                 $contentType .= " name=\"{$details['name']}\"";
-                Assert::assertContains($contentType, $partHeaders);
+                Assert::assertStringContainsString($contentType, $partHeaders);
                 if ($details['disposition'] === true) {
-                    Assert::assertContains(
+                    Assert::assertStringContainsString(
                         'Content-Disposition: attachment; filename="' . $details['name'] . '"',
                         $partHeaders
                     );
                 } else {
-                    Assert::assertNotContains('Content-Disposition', $partHeaders);
+                    Assert::assertStringNotContainsStringIgnoringCase('Content-Disposition', $partHeaders);
                 }
             }
         }

--- a/tests/AssertAttachmentsEmail.php
+++ b/tests/AssertAttachmentsEmail.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Tests;

--- a/tests/AssertBounceHeadEmail.php
+++ b/tests/AssertBounceHeadEmail.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Tests;

--- a/tests/AssertBounceHeadEmail.php
+++ b/tests/AssertBounceHeadEmail.php
@@ -29,7 +29,7 @@ class AssertBounceHeadEmail
         $primaryPart = $mail->getPart();
         Assert::assertInstanceOf(MultipartReport::class, $primaryPart);
         Assert::assertEquals('multipart/report', $primaryPart->getType());
-        Assert::assertContains('; report-type=delivery-status', $primaryPart->getEncodedHeaders());
+        Assert::assertStringContainsString('; report-type=delivery-status', $primaryPart->getEncodedHeaders());
 
         $reportParts = $primaryPart->getParts();
         Assert::assertCount(3, $reportParts);

--- a/tests/AssertBounceMsgEmail.php
+++ b/tests/AssertBounceMsgEmail.php
@@ -31,7 +31,7 @@ class AssertBounceMsgEmail
         $primaryPart = $mail->getPart();
         Assert::assertInstanceOf(MultipartReport::class, $primaryPart);
         Assert::assertEquals('multipart/report', $primaryPart->getType());
-        Assert::assertContains('; report-type=delivery-status', $primaryPart->getEncodedHeaders());
+        Assert::assertStringContainsString('; report-type=delivery-status', $primaryPart->getEncodedHeaders());
 
         $reportParts = $primaryPart->getParts();
         Assert::assertCount(3, $reportParts);

--- a/tests/AssertBounceMsgEmail.php
+++ b/tests/AssertBounceMsgEmail.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Tests;

--- a/tests/AssertContentAttachmentEmail.php
+++ b/tests/AssertContentAttachmentEmail.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Tests;

--- a/tests/AssertHtmlEmail.php
+++ b/tests/AssertHtmlEmail.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Tests;

--- a/tests/Content/AbstractContentTest.php
+++ b/tests/Content/AbstractContentTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Tests\Content;

--- a/tests/Content/AbstractContentTest.php
+++ b/tests/Content/AbstractContentTest.php
@@ -14,7 +14,7 @@ class AbstractContentTest extends TestCase
      */
     protected $part;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->part = $this->getMockForAbstractClass(AbstractContent::class);
     }

--- a/tests/Content/AttachmentTest.php
+++ b/tests/Content/AttachmentTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Tests\Content;

--- a/tests/Content/AttachmentTest.php
+++ b/tests/Content/AttachmentTest.php
@@ -113,7 +113,7 @@ class AttachmentTest extends TestCase
         $part = new Attachment('example-file-name.png');
 
         $actual = $part->getEncodedHeaders();
-        $this->assertNotContains('Content-Disposition:', $actual);
+        $this->assertStringNotContainsStringIgnoringCase('Content-Disposition:', $actual);
     }
 
     public function testNoDispositionNull()
@@ -121,7 +121,7 @@ class AttachmentTest extends TestCase
         $part = new Attachment('example-file-name.png', null);
 
         $actual = $part->getEncodedHeaders();
-        $this->assertNotContains('Content-Disposition:', $actual);
+        $this->assertStringNotContainsStringIgnoringCase('Content-Disposition:', $actual);
     }
 
     public function testGetEncodedHeaders()

--- a/tests/Content/ContentTest.php
+++ b/tests/Content/ContentTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Tests\Content;

--- a/tests/Content/HtmlTest.php
+++ b/tests/Content/HtmlTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Tests\Content;

--- a/tests/Content/HtmlTest.php
+++ b/tests/Content/HtmlTest.php
@@ -14,7 +14,7 @@ class HtmlTest extends TestCase
     protected $part;
 
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->part = new Html();
     }

--- a/tests/Content/TextTest.php
+++ b/tests/Content/TextTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Tests\Content;

--- a/tests/Content/TextTest.php
+++ b/tests/Content/TextTest.php
@@ -13,7 +13,7 @@ class TextTest extends TestCase
      */
     protected $part;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->part = new Text();
     }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -13,7 +13,7 @@ class FactoryTest extends TestCase
 {
     use PHPMock;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->defineFunctionMock('\Phlib\Mail', 'mailparse_msg_parse');
         $this->defineFunctionMock('\Phlib\Mail', 'mailparse_msg_parse_file');

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Tests;

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Tests;

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Tests;

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -17,7 +17,7 @@ class MailTest extends TestCase
      */
     protected $mail;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->mail = new Mail();
     }

--- a/tests/Mime/AbstractMimeTest.php
+++ b/tests/Mime/AbstractMimeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Tests\Mime;

--- a/tests/Mime/AbstractMimeTest.php
+++ b/tests/Mime/AbstractMimeTest.php
@@ -16,7 +16,7 @@ class AbstractMimeTest extends TestCase
      */
     protected $part;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->part = $this->getMockForAbstractClass(AbstractMime::class);
     }

--- a/tests/Mime/MimeTest.php
+++ b/tests/Mime/MimeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Tests\Mime;

--- a/tests/Mime/MultipartAlternativeTest.php
+++ b/tests/Mime/MultipartAlternativeTest.php
@@ -13,7 +13,7 @@ class MultipartAlternativeTest extends TestCase
      */
     protected $part;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->part = new MultipartAlternative();
     }

--- a/tests/Mime/MultipartAlternativeTest.php
+++ b/tests/Mime/MultipartAlternativeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Tests\Mime;

--- a/tests/Mime/MultipartMixedTest.php
+++ b/tests/Mime/MultipartMixedTest.php
@@ -13,7 +13,7 @@ class MultipartMixedTest extends TestCase
      */
     protected $part;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->part = new MultipartMixed();
     }

--- a/tests/Mime/MultipartMixedTest.php
+++ b/tests/Mime/MultipartMixedTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Tests\Mime;

--- a/tests/Mime/MultipartRelatedTest.php
+++ b/tests/Mime/MultipartRelatedTest.php
@@ -13,7 +13,7 @@ class MultipartRelatedTest extends TestCase
      */
     protected $part;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->part = new MultipartRelated();
     }

--- a/tests/Mime/MultipartRelatedTest.php
+++ b/tests/Mime/MultipartRelatedTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Tests\Mime;

--- a/tests/Mime/MultipartReportTest.php
+++ b/tests/Mime/MultipartReportTest.php
@@ -13,7 +13,7 @@ class MultipartReportTest extends TestCase
      */
     protected $part;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->part = new MultipartReport();
     }

--- a/tests/Mime/MultipartReportTest.php
+++ b/tests/Mime/MultipartReportTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Phlib\Mail\Tests\Mime;


### PR DESCRIPTION
Targeting the next major version, we can remove support for those versions of PHP no longer actively supported by the PHP Project.

This then also allows upgrading to Symfony/Mime v5 (there are no changes between 4.4 and 5.0 other than dropping support for PHP v7.1) [Compare](https://github.com/symfony/mime/compare/4.4...v5.0.0)

Can also move to PHPUnit v8, and finally, some minor fixes for PSR-12.