### PR TITLE
Use Symfony Mime for all headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - *symfony/mime* added as a required dependency.
-- Dedicated setter and getter methods on `Mail` for Message-Id header.
+- Dedicated setter and getter methods for primary `Mail` headers: Message-Id,
+  (Origination) Date, Received, In-Reply-To and References. 
 ### Fixed
 - Encoding full mailbox header when Display Name contains extended characters.
   Now only encode the affected part of the Display Name, so the address stays
@@ -17,8 +18,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - **BC break**: Removed support for PHP v7.1 and v7.2 as they are no longer
 [actively supported](https://php.net/supported-versions.php) by the PHP project
 - **BC break**: Removed `Mail::formatAddress()`
-- **BC break**: `Mail::addHeader()` no longer allows setting Message-Id.
-  Use the new dedicated `Mail::setMessageId()` method.
+- **BC break**: `Mail::addHeader()` no longer allows setting Message-Id,
+  (Origination) Date, Received, In-Reply-To and References.
+  Use the new dedicated setter methods.
 
 ## [3.2.1] - 2019-07-30
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 - **BC break**: Removed support for PHP v7.1 and v7.2 as they are no longer
 [actively supported](https://php.net/supported-versions.php) by the PHP project
+- **BC break**: Removed `AbstractPart::removeHeader()` for specific name and
+  value combination. All values for a single name can still be removed using
+  `AbstractPart::clearHeader($name)`
 - **BC break**: Removed `Mail::formatAddress()`
 - **BC break**: `Mail::addHeader()` no longer allows setting Message-Id,
   (Origination) Date, Received, In-Reply-To and References.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - *symfony/mime* added as a required dependency.
+- Dedicated setter and getter methods on `Mail` for Message-Id header.
 ### Fixed
 - Encoding full mailbox header when Display Name contains extended characters.
   Now only encode the affected part of the Display Name, so the address stays
@@ -16,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - **BC break**: Removed support for PHP v7.1 and v7.2 as they are no longer
 [actively supported](https://php.net/supported-versions.php) by the PHP project
 - **BC break**: Removed `Mail::formatAddress()`
+- **BC break**: `Mail::addHeader()` no longer allows setting Message-Id.
+  Use the new dedicated `Mail::setMessageId()` method.
 
 ## [3.2.1] - 2019-07-30
 ### Fixed

--- a/src/AbstractPart.php
+++ b/src/AbstractPart.php
@@ -7,6 +7,7 @@ namespace Phlib\Mail;
 use Phlib\Mail\Exception\InvalidArgumentException;
 use Symfony\Component\Mime\Header\HeaderInterface;
 use Symfony\Component\Mime\Header\Headers;
+use Symfony\Component\Mime\Header\ParameterizedHeader;
 use Symfony\Component\Mime\Header\UnstructuredHeader;
 
 abstract class AbstractPart
@@ -175,14 +176,14 @@ abstract class AbstractPart
         }
 
         if ($this->type) {
-            $contentType = $this->type;
+            $contentTypeHeader = new ParameterizedHeader('Content-Type', $this->type);
             if ($this->charset && !($this instanceof Mime\AbstractMime)) {
-                $contentType .= "; charset=\"{$this->charset}\"";
+                $contentTypeHeader->setParameter('charset', $this->charset);
             }
 
-            $contentType = $this->addContentTypeParameters($contentType);
+            $this->addContentTypeParameters($contentTypeHeader);
 
-            $headers->addTextHeader('Content-Type', $contentType);
+            $headers->add($contentTypeHeader);
 
             if ($this->encoding) {
                 $headers->addTextHeader('Content-Transfer-Encoding', $this->encoding);
@@ -193,12 +194,12 @@ abstract class AbstractPart
     /**
      * Allow concrete classes to add additional content type parameters to the base value
      *
-     * @param string $contentType
-     * @return string
+     * @param ParameterizedHeader $contentTypeHeader
+     * @return void
      */
-    protected function addContentTypeParameters(string $contentType): string
+    protected function addContentTypeParameters(ParameterizedHeader $contentTypeHeader): void
     {
-        return $contentType;
+        // void
     }
 
     public function setCharset(string $charset): self

--- a/src/AbstractPart.php
+++ b/src/AbstractPart.php
@@ -106,21 +106,6 @@ abstract class AbstractPart
         return $this;
     }
 
-    public function removeHeader(string $name, string $value): self
-    {
-        $name = strtolower($name);
-        if (array_key_exists($name, $this->headers)) {
-            foreach ($this->headers[$name] as $idx => $headerValue) {
-                if ($headerValue == $value) {
-                    unset($this->headers[$name][$idx]);
-                    break;
-                }
-            }
-        }
-
-        return $this;
-    }
-
     public function getHeaders(): array
     {
         return $this->headers;

--- a/src/Content/Attachment.php
+++ b/src/Content/Attachment.php
@@ -7,6 +7,7 @@ namespace Phlib\Mail\Content;
 use Phlib\Mail\AbstractPart;
 use Phlib\Mail\Exception\InvalidArgumentException;
 use Symfony\Component\Mime\Header\Headers;
+use Symfony\Component\Mime\Header\ParameterizedHeader;
 
 /**
  * Attachment class used to represent attachments as Mail content
@@ -95,20 +96,14 @@ class Attachment extends AbstractContent
 
         if ($this->disposition) {
             // RFC 2183
-            $headers->addTextHeader('Content-Disposition', "{$this->disposition}; filename=\"{$this->name}\"");
+            $headers->addParameterizedHeader('Content-Disposition', $this->disposition, ['filename' => $this->name]);
         }
     }
 
-    /**
-     * Add additional content type parameters to the base value
-     *
-     * @param string $contentType
-     * @return string
-     */
-    protected function addContentTypeParameters(string $contentType): string
+    protected function addContentTypeParameters(ParameterizedHeader $contentTypeHeader): void
     {
-        $contentType .= "; name=\"{$this->name}\"";
+        $contentTypeHeader->setParameter('name', $this->name);
 
-        return parent::addContentTypeParameters($contentType);
+        parent::addContentTypeParameters($contentTypeHeader);
     }
 }

--- a/src/Content/Attachment.php
+++ b/src/Content/Attachment.php
@@ -6,6 +6,7 @@ namespace Phlib\Mail\Content;
 
 use Phlib\Mail\AbstractPart;
 use Phlib\Mail\Exception\InvalidArgumentException;
+use Symfony\Component\Mime\Header\Headers;
 
 /**
  * Attachment class used to represent attachments as Mail content
@@ -88,15 +89,14 @@ class Attachment extends AbstractContent
         return $this;
     }
 
-    public function getEncodedHeaders(): string
+    protected function buildHeaders(Headers $headers): void
     {
-        $headers = parent::getEncodedHeaders();
+        parent::buildHeaders($headers);
+
         if ($this->disposition) {
             // RFC 2183
-            $headers .= "Content-Disposition: {$this->disposition}; filename=\"{$this->name}\"\r\n";
+            $headers->addTextHeader('Content-Disposition', "{$this->disposition}; filename=\"{$this->name}\"");
         }
-
-        return $headers;
     }
 
     /**

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -176,6 +176,10 @@ class Factory
                                 );
                             }
                             break;
+                        case 'message-id':
+                            $messageId = $this->parseEmailAddresses($headerText);
+                            $mail->setMessageId($messageId[0]['address']);
+                            break;
                         case 'subject':
                             $mail->setSubject($headerText);
                             break;

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -151,9 +151,9 @@ class Factory
 
                 try {
                     switch (strtolower($headerKey)) {
+                        case 'return-path':
                         case 'from':
                         case 'reply-to':
-                        case 'return-path':
                             $addresses = $this->parseEmailAddresses($headerText);
                             $method = 'set' . str_replace(' ', '', ucwords(
                                 str_replace('-', ' ', strtolower($headerKey))
@@ -165,8 +165,8 @@ class Factory
                                 );
                             }
                             break;
-                        case 'cc':
                         case 'to':
+                        case 'cc':
                             $addresses = $this->parseEmailAddresses($headerText);
                             $method = 'add' . ucwords(strtolower($headerKey));
                             foreach ($addresses as $address) {

--- a/src/Mail.php
+++ b/src/Mail.php
@@ -8,7 +8,6 @@ use Phlib\Mail\Exception\InvalidArgumentException;
 use Phlib\Mail\Exception\RuntimeException;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Exception\RfcComplianceException;
-use Symfony\Component\Mime\Header\AbstractHeader;
 use Symfony\Component\Mime\Header\DateHeader;
 use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\Header\IdentificationHeader;
@@ -126,10 +125,8 @@ class Mail extends AbstractPart
         return $this->part;
     }
 
-    public function getEncodedHeaders(): string
+    protected function buildHeaders(Headers $headers): void
     {
-        $headers = new Headers();
-
         // Add headers in order defined in RFC5322 §3.6
 
         // Return-path and Received are 'trace' fields so must be first - RFC5322 §3.6.7
@@ -180,23 +177,7 @@ class Mail extends AbstractPart
             $headers->addTextHeader('MIME-Version', '1.0');
         }
 
-        // Set correct charset on all headers
-        $charset = $this->charset;
-        if (!$charset) {
-            $charset = mb_internal_encoding();
-        }
-        /** @var AbstractHeader $header */
-        foreach ($headers->all() as $header) {
-            // Symfony/Mime AbstractHeader defaults to 76 !?
-            $header->setMaxLineLength(78);
-            // Set this part's charset to the headers
-            $header->setCharset($charset);
-
-        }
-
-        $headersString = $headers->toString();
-
-        return $headersString . parent::getEncodedHeaders();
+        parent::buildHeaders($headers);
     }
 
     /**

--- a/src/Mail.php
+++ b/src/Mail.php
@@ -126,11 +126,17 @@ class Mail extends AbstractPart
         }
 
         // Set correct charset on all headers
-        if ($this->charset) {
-            /** @var AbstractHeader $header */
-            foreach ($headers->all() as $header) {
-                $header->setCharset($this->charset);
-            }
+        $charset = $this->charset;
+        if (!$charset) {
+            $charset = mb_internal_encoding();
+        }
+        /** @var AbstractHeader $header */
+        foreach ($headers->all() as $header) {
+            // Symfony/Mime AbstractHeader defaults to 76 !?
+            $header->setMaxLineLength(78);
+            // Set this part's charset to the headers
+            $header->setCharset($charset);
+
         }
 
         $headersString = $headers->toString();

--- a/src/Mail.php
+++ b/src/Mail.php
@@ -10,6 +10,7 @@ use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Exception\RfcComplianceException;
 use Symfony\Component\Mime\Header\AbstractHeader;
 use Symfony\Component\Mime\Header\Headers;
+use Symfony\Component\Mime\Header\IdentificationHeader;
 
 class Mail extends AbstractPart
 {
@@ -35,6 +36,7 @@ class Mail extends AbstractPart
         'reply-to',
         'to',
         'cc',
+        'message-id',
         'subject',
     ];
 
@@ -62,6 +64,11 @@ class Mail extends AbstractPart
      * @var Address[]
      */
     private $cc = [];
+
+    /**
+     * @var IdentificationHeader
+     */
+    private $messageId;
 
     /**
      * @var string?
@@ -118,6 +125,10 @@ class Mail extends AbstractPart
 
         if (!empty($this->cc)) {
             $headers->addMailboxListHeader('Cc', $this->cc);
+        }
+
+        if ($this->messageId) {
+            $headers->add($this->messageId);
         }
 
         if ($this->subject) {
@@ -286,6 +297,24 @@ class Mail extends AbstractPart
         $this->cc = [];
 
         return $this;
+    }
+
+    public function setMessageId(string $messageId): self
+    {
+        try {
+            $this->messageId = new IdentificationHeader('Message-Id', $messageId);
+        } catch (RfcComplianceException $e) {
+            throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+        }
+        return $this;
+    }
+
+    public function getMessageId(): ?string
+    {
+        if ($this->messageId === null) {
+            return null;
+        }
+        return $this->messageId->getBody()[0];
     }
 
     public function setSubject(string $subject): self

--- a/src/Mail.php
+++ b/src/Mail.php
@@ -9,8 +9,10 @@ use Phlib\Mail\Exception\RuntimeException;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Exception\RfcComplianceException;
 use Symfony\Component\Mime\Header\AbstractHeader;
+use Symfony\Component\Mime\Header\DateHeader;
 use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\Header\IdentificationHeader;
+use Symfony\Component\Mime\Header\UnstructuredHeader;
 
 class Mail extends AbstractPart
 {
@@ -32,11 +34,15 @@ class Mail extends AbstractPart
         'content-transfer-encoding',
         'mime-version',
         'return-path',
+        'received',
+        'date',
         'from',
         'reply-to',
         'to',
         'cc',
         'message-id',
+        'in-reply-to',
+        'references',
         'subject',
     ];
 
@@ -44,6 +50,16 @@ class Mail extends AbstractPart
      * @var Address?
      */
     private $returnPath;
+
+    /**
+     * @var UnstructuredHeader[]
+     */
+    private $received = [];
+
+    /**
+     * @var DateHeader
+     */
+    private $originationDate;
 
     /**
      * @var Address?
@@ -69,6 +85,16 @@ class Mail extends AbstractPart
      * @var IdentificationHeader
      */
     private $messageId;
+
+    /**
+     * @var IdentificationHeader
+     */
+    private $inReplyTo;
+
+    /**
+     * @var IdentificationHeader
+     */
+    private $references;
 
     /**
      * @var string?
@@ -106,9 +132,16 @@ class Mail extends AbstractPart
 
         // Add headers in order defined in RFC5322 §3.6
 
-        // Return-path is a 'trace' field so must be first - RFC5322 §3.6.7
+        // Return-path and Received are 'trace' fields so must be first - RFC5322 §3.6.7
         if ($this->returnPath) {
             $headers->addPathHeader('Return-Path', $this->returnPath);
+        }
+        foreach ($this->received as $received) {
+            $headers->add($received);
+        }
+
+        if ($this->originationDate) {
+            $headers->add($this->originationDate);
         }
 
         if ($this->from) {
@@ -129,6 +162,14 @@ class Mail extends AbstractPart
 
         if ($this->messageId) {
             $headers->add($this->messageId);
+        }
+
+        if ($this->inReplyTo) {
+            $headers->add($this->inReplyTo);
+        }
+
+        if ($this->references) {
+            $headers->add($this->references);
         }
 
         if ($this->subject) {
@@ -189,6 +230,38 @@ class Mail extends AbstractPart
         }
 
         return $this->returnPath->getAddress();
+    }
+
+    public function addReceived(string $received, \DateTimeImmutable $dateTime): self
+    {
+        // RFC5322 §3.6.7 https://tools.ietf.org/html/rfc5322#section-3.6.7
+        $value = $received . '; ' . $dateTime->format(\DateTime::RFC2822);
+        $this->received[] = new UnstructuredHeader('Received', $value);
+
+        return $this;
+    }
+
+    public function getReceived(): array
+    {
+        $received = [];
+        foreach ($this->received as $header) {
+            $received[] = $header->getBody();
+        }
+        return $received;
+    }
+
+    public function setOriginationDate(\DateTimeImmutable $originationDate): self
+    {
+        $this->originationDate = new DateHeader('Date', $originationDate);
+        return $this;
+    }
+
+    public function getOriginationDate(): ?\DateTimeImmutable
+    {
+        if ($this->originationDate === null) {
+            return null;
+        }
+        return $this->originationDate->getBody();
     }
 
     /**
@@ -315,6 +388,42 @@ class Mail extends AbstractPart
             return null;
         }
         return $this->messageId->getBody()[0];
+    }
+
+    public function setInReplyTo(array $messageIds): self
+    {
+        try {
+            $this->inReplyTo = new IdentificationHeader('In-Reply-To', $messageIds);
+        } catch (RfcComplianceException $e) {
+            throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+        }
+        return $this;
+    }
+
+    public function getInReplyTo(): ?array
+    {
+        if ($this->inReplyTo === null) {
+            return null;
+        }
+        return $this->inReplyTo->getBody();
+    }
+
+    public function setReferences(array $messageIds): self
+    {
+        try {
+            $this->references = new IdentificationHeader('References', $messageIds);
+        } catch (RfcComplianceException $e) {
+            throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+        }
+        return $this;
+    }
+
+    public function getReferences(): ?array
+    {
+        if ($this->references === null) {
+            return null;
+        }
+        return $this->references->getBody();
     }
 
     public function setSubject(string $subject): self

--- a/src/Mime/AbstractMime.php
+++ b/src/Mime/AbstractMime.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phlib\Mail\Mime;
 
 use Phlib\Mail\AbstractPart;
+use Symfony\Component\Mime\Header\ParameterizedHeader;
 
 abstract class AbstractMime extends AbstractPart
 {
@@ -81,18 +82,12 @@ abstract class AbstractMime extends AbstractPart
         return $this->getEncodedHeaders() . $content;
     }
 
-    /**
-     * Add additional content type parameters to the base value.
-     *
-     * @param string $contentType
-     * @return string
-     */
-    protected function addContentTypeParameters(string $contentType): string
+    protected function addContentTypeParameters(ParameterizedHeader $contentTypeHeader): void
     {
         if ($this->boundary) {
-            $contentType .= ";\r\n\tboundary=\"{$this->boundary}\"";
+            $contentTypeHeader->setParameter('boundary', $this->boundary);
         }
 
-        return $contentType;
+        parent::addContentTypeParameters($contentTypeHeader);
     }
 }

--- a/src/Mime/MultipartReport.php
+++ b/src/Mime/MultipartReport.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Phlib\Mail\Mime;
 
+use Symfony\Component\Mime\Header\ParameterizedHeader;
+
 class MultipartReport extends AbstractMime
 {
     /**
@@ -39,18 +41,12 @@ class MultipartReport extends AbstractMime
         return $this->reportType;
     }
 
-    /**
-     * Add additional content type parameters to the base value
-     *
-     * @param string $contentType
-     * @return string
-     */
-    protected function addContentTypeParameters(string $contentType): string
+    protected function addContentTypeParameters(ParameterizedHeader $contentTypeHeader): void
     {
         if ($this->reportType) {
-            $contentType .= "; report-type={$this->reportType}";
+            $contentTypeHeader->setParameter('report-type', $this->reportType);
         }
 
-        return parent::addContentTypeParameters($contentType);
+        parent::addContentTypeParameters($contentTypeHeader);
     }
 }

--- a/tests/AbstractPartTest.php
+++ b/tests/AbstractPartTest.php
@@ -172,23 +172,6 @@ class AbstractPartTest extends TestCase
     }
 
     /**
-     * Message-Id header must never be encoded
-     * An underscore triggers mb_encode_mimeheader() to encode the string even if not necessary
-     * Even when longer than soft limit of 78 chars, we don't want Message-Id to be wrapped
-     */
-    public function testGetEncodedHeadersMessageId()
-    {
-        $name = 'Message-Id';
-        $value = '<5ba50e335feeb_58fbb46426474f8d8108b1f8e02bad29@mail.long.example.com>';
-        $this->part->addHeader($name, $value);
-
-        $expected = "$name: $value\r\n";
-
-        $actual = $this->part->getEncodedHeaders();
-        $this->assertEquals($expected, $actual);
-    }
-
-    /**
      * An underscore triggers mb_encode_mimeheader() to encode the string even if not necessary
      */
     public function testGetEncodedHeadersNotEncodedForUnderscore()

--- a/tests/AbstractPartTest.php
+++ b/tests/AbstractPartTest.php
@@ -31,14 +31,6 @@ class AbstractPartTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testAddHeaderFilterValue()
-    {
-        $this->part->addHeader('test', "va\rl\nu\te");
-        $expected = ['value'];
-        $actual = $this->part->getHeader('test');
-        $this->assertEquals($expected, $actual);
-    }
-
     public function testAddHeaderInvalidName()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -135,7 +127,8 @@ class AbstractPartTest extends TestCase
         // Check encoding
         $value = "line1\r\nline2, high ascii > é <\r\n";
         $this->part->addHeader('Subject', $value);
-        $expected .= "Subject: line1line2, high ascii > =?UTF-8?B?" . base64_encode('é <') . "?=\r\n";
+        $expected .= "Subject: =?UTF-8?Q?line1?=\r\n" .
+            " =?UTF-8?Q?line2=2C?= high ascii > =?UTF-8?Q?=C3=A9?= <\r\n";
 
         $actual = $this->part->getEncodedHeaders();
         $this->assertEquals($expected, $actual);
@@ -143,8 +136,8 @@ class AbstractPartTest extends TestCase
 
     public function testGetEncodedHeadersWhitespace()
     {
-        $name = 'From';
-        $value = ' "From" <from@mail.example.com> ';
+        $name = 'X-Test';
+        $value = ' "Name" <from@mail.example.com> ';
         $this->part->addHeader($name, $value);
 
         $expected = "$name: " . trim($value) . "\r\n";
@@ -173,8 +166,8 @@ class AbstractPartTest extends TestCase
      */
     public function testGetEncodedHeadersNotEncodedForEquals()
     {
-        $name = 'From';
-        $value = '"From=" <equals@mail.example.com>';
+        $name = 'X-Test';
+        $value = '"Name=" <equals@mail.example.com>';
         $this->part->addHeader($name, $value);
 
         $expected = "$name: $value\r\n";

--- a/tests/AbstractPartTest.php
+++ b/tests/AbstractPartTest.php
@@ -93,24 +93,6 @@ class AbstractPartTest extends TestCase
         $this->assertEquals($expectedAfter, $actualAfter);
     }
 
-    public function testRemoveHeader()
-    {
-        $this->part->addHeader('test', 'value1');
-        $this->part->addHeader('test', 'value2');
-        $expectedBefore = ['value1', 'value2'];
-        $actualBefore = $this->part->getHeader('test');
-        $this->assertEquals($expectedBefore, $actualBefore);
-
-        $this->part->removeHeader('test', 'value1');
-        $actualAfter = $this->part->getHeader('test');
-        $this->assertNotContains('value1', $actualAfter);
-        $this->assertContains('value2', $actualAfter);
-
-        $this->part->removeHeader('test', 'value2');
-        $this->assertEmpty($this->part->getHeader('test'));
-        $this->assertFalse($this->part->hasHeader('test'));
-    }
-
     public function testGetHeaders()
     {
         $expected = $this->addHeaders();

--- a/tests/AssertAttachmentsEmail.php
+++ b/tests/AssertAttachmentsEmail.php
@@ -117,13 +117,13 @@ class AssertAttachmentsEmail
                 $partHeaders = $part->getEncodedHeaders();
                 $contentTypeRegex = '/Content-Type: ' . preg_quote($details['type'], '/') . ';';
                 if ($details['charset']) {
-                    $contentTypeRegex .= '\s+charset="' . preg_quote($details['charset'], '/') . '";';
+                    $contentTypeRegex .= '\s+charset=' . preg_quote($details['charset'], '/') . ';';
                 }
-                $contentTypeRegex .= '\s+name="' . preg_quote($details['name'], '/') . '"/';
+                $contentTypeRegex .= '\s+name=' . preg_quote($details['name'], '/') . '/';
                 Assert::assertRegExp($contentTypeRegex, $partHeaders);
                 if ($details['disposition'] === true) {
                     Assert::assertRegExp(
-                        '/Content-Disposition: attachment;\s+filename="' . $details['name'] . '"/',
+                        '/Content-Disposition: attachment;\s+filename=' . $details['name'] . '/',
                         $partHeaders
                     );
                 } else {

--- a/tests/AssertAttachmentsEmail.php
+++ b/tests/AssertAttachmentsEmail.php
@@ -115,15 +115,15 @@ class AssertAttachmentsEmail
             // Test attachments
             if ($part instanceof Attachment || $part instanceof Content) {
                 $partHeaders = $part->getEncodedHeaders();
-                $contentType = "Content-Type: {$details['type']};";
+                $contentTypeRegex = '/Content-Type: ' . preg_quote($details['type'], '/') . ';';
                 if ($details['charset']) {
-                    $contentType .= " charset=\"{$details['charset']}\";";
+                    $contentTypeRegex .= '\s+charset="' . preg_quote($details['charset'], '/') . '";';
                 }
-                $contentType .= " name=\"{$details['name']}\"";
-                Assert::assertStringContainsString($contentType, $partHeaders);
+                $contentTypeRegex .= '\s+name="' . preg_quote($details['name'], '/') . '"/';
+                Assert::assertRegExp($contentTypeRegex, $partHeaders);
                 if ($details['disposition'] === true) {
-                    Assert::assertStringContainsString(
-                        'Content-Disposition: attachment; filename="' . $details['name'] . '"',
+                    Assert::assertRegExp(
+                        '/Content-Disposition: attachment;\s+filename="' . $details['name'] . '"/',
                         $partHeaders
                     );
                 } else {

--- a/tests/Content/AttachmentTest.php
+++ b/tests/Content/AttachmentTest.php
@@ -26,9 +26,9 @@ class AttachmentTest extends TestCase
         $this->assertEquals($content, $part->getContent());
 
         // Name
-        $expected = "Content-Type: {$expectedType}; name=\"{$basename}\"\r\n"
+        $expected = "Content-Type: {$expectedType}; name={$basename}\r\n"
                     . "Content-Transfer-Encoding: base64\r\n"
-                    . "Content-Disposition: attachment; filename=\"{$basename}\"\r\n";
+                    . "Content-Disposition: attachment; filename={$basename}\r\n";
 
         $actual = $part->getEncodedHeaders();
         $this->assertEquals($expected, $actual);
@@ -105,8 +105,8 @@ class AttachmentTest extends TestCase
         $part = new Attachment($filename, $disposition, 'application/octet-stream');
 
         $actual = $part->getEncodedHeaders();
-        $this->assertRegExp("/Content-Type: [^;]+; name=\"{$filename}\"/", $actual);
-        $this->assertRegExp("/Content-Disposition: {$disposition}; filename=\"{$filename}\"/", $actual);
+        $this->assertRegExp("/Content-Type: [^;]+; name={$filename}/", $actual);
+        $this->assertRegExp("/Content-Disposition: {$disposition}; filename={$filename}/", $actual);
     }
 
     public function testNoDispositionDefault()
@@ -132,9 +132,9 @@ class AttachmentTest extends TestCase
 
         $part = new Attachment($filename, $disposition);
 
-        $expected = "Content-Type: application/octet-stream; name=\"{$filename}\"\r\n"
+        $expected = "Content-Type: application/octet-stream; name={$filename}\r\n"
             . "Content-Transfer-Encoding: base64\r\n"
-            . "Content-Disposition: {$disposition}; filename=\"{$filename}\"\r\n";
+            . "Content-Disposition: {$disposition}; filename={$filename}\r\n";
 
         $actual = $part->getEncodedHeaders();
         $this->assertEquals($expected, $actual);

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -511,7 +511,7 @@ class MailTest extends TestCase
     public function testToString()
     {
         $expectedHeaders = $this->addHeaders();
-        $expectedHeaders['Content-Type'] = 'application/octet-stream; charset="UTF-8"';
+        $expectedHeaders['Content-Type'] = 'application/octet-stream; charset=UTF-8';
         $expectedHeaders['Content-Transfer-Encoding'] = 'quoted-printable';
 
         $content = 'test content';

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -176,6 +176,79 @@ class MailTest extends TestCase
         }
     }
 
+    public function testSetGetReturnPath()
+    {
+        $address = 'return-path@example.com';
+        $this->mail->setReturnPath($address);
+
+        $this->assertEquals($address, $this->mail->getReturnPath());
+    }
+
+    public function testSetReturnPathInvalid()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->mail->setReturnPath('invalid address');
+    }
+
+    public function testClearReturnPath()
+    {
+        $address = 'return-path@example.com';
+        $this->mail->setReturnPath($address);
+        $this->assertEquals($address, $this->mail->getReturnPath());
+
+        $this->mail->clearReturnPath();
+        $this->assertEquals(null, $this->mail->getReturnPath());
+    }
+
+    public function testGetReturnPathDefault(): void
+    {
+        $this->assertSame(null, $this->mail->getReturnPath());
+    }
+
+    public function testSetGetFrom()
+    {
+        $data = [
+            'from@example.com',
+            'From Alias'
+        ];
+        $this->mail->setFrom($data[0], $data[1]);
+
+        $this->assertEquals($data, $this->mail->getFrom());
+    }
+
+    public function testSetFromInvalid()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->mail->setFrom('invalid address');
+    }
+
+    public function testGetFromDefault(): void
+    {
+        $this->assertSame(null, $this->mail->getFrom());
+    }
+
+    public function testSetGetReplyTo()
+    {
+        $data = [
+            'reply-to@example.com',
+            'Reply-To Alias'
+        ];
+        $this->mail->setReplyTo($data[0], $data[1]);
+
+        $this->assertEquals($data, $this->mail->getReplyTo());
+    }
+
+    public function testSetReplyToInvalid()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->mail->setReplyTo('invalid address');
+    }
+
+    public function testGetReplyToDefault(): void
+    {
+        $this->assertSame(null, $this->mail->getReplyTo());
+    }
+
     public function testAddGetTo()
     {
         $data = [
@@ -246,79 +319,6 @@ class MailTest extends TestCase
         $this->assertSame([], $this->mail->getCc());
     }
 
-    public function testSetGetReplyTo()
-    {
-        $data = [
-            'reply-to@example.com',
-            'Reply-To Alias'
-        ];
-        $this->mail->setReplyTo($data[0], $data[1]);
-
-        $this->assertEquals($data, $this->mail->getReplyTo());
-    }
-
-    public function testSetReplyToInvalid()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->mail->setReplyTo('invalid address');
-    }
-
-    public function testGetReplyToDefault(): void
-    {
-        $this->assertSame(null, $this->mail->getReplyTo());
-    }
-
-    public function testSetGetReturnPath()
-    {
-        $address = 'return-path@example.com';
-        $this->mail->setReturnPath($address);
-
-        $this->assertEquals($address, $this->mail->getReturnPath());
-    }
-
-    public function testSetReturnPathInvalid()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->mail->setReturnPath('invalid address');
-    }
-
-    public function testClearReturnPath()
-    {
-        $address = 'return-path@example.com';
-        $this->mail->setReturnPath($address);
-        $this->assertEquals($address, $this->mail->getReturnPath());
-
-        $this->mail->clearReturnPath();
-        $this->assertEquals(null, $this->mail->getReturnPath());
-    }
-
-    public function testGetReturnPathDefault(): void
-    {
-        $this->assertSame(null, $this->mail->getReturnPath());
-    }
-
-    public function testSetGetFrom()
-    {
-        $data = [
-            'from@example.com',
-            'From Alias'
-        ];
-        $this->mail->setFrom($data[0], $data[1]);
-
-        $this->assertEquals($data, $this->mail->getFrom());
-    }
-
-    public function testSetFromInvalid()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->mail->setFrom('invalid address');
-    }
-
-    public function testGetFromDefault(): void
-    {
-        $this->assertSame(null, $this->mail->getFrom());
-    }
-
     public function testSetGetSubject()
     {
         $subject = 'subject line';
@@ -331,7 +331,7 @@ class MailTest extends TestCase
     {
         $this->assertSame(null, $this->mail->getSubject());
     }
-  
+
     public function testHasAttachmentFalse()
     {
         $this->assertEquals(false, $this->mail->hasAttachment());
@@ -399,20 +399,20 @@ class MailTest extends TestCase
     {
         $this->mail->setReturnPath('return-path@example.com');
         $this->mail->setFrom('from@example.com', "From Alias \xf0\x9f\x93\xa7 envelope");
-        $this->mail->setSubject("subject line with \xf0\x9f\x93\xa7 envelope");
+        $this->mail->setReplyTo('reply-to@example.com');
         $this->mail->addTo('to+1@example.com', "To Alias 1 \xf0\x9f\x93\xa7 envelope");
         $this->mail->addTo('to+2@example.com', "To Alias 2 \xf0\x9f\x93\xa7 envelope");
         $this->mail->addCc('cc@example.com');
-        $this->mail->setReplyTo('reply-to@example.com');
+        $this->mail->setSubject("subject line with \xf0\x9f\x93\xa7 envelope");
 
         $expected = [
-            "Return-Path" => '<return-path@example.com>',
-            "From" => "From Alias \xf0\x9f\x93\xa7 envelope <from@example.com>",
-            "Subject" => "subject line with \xf0\x9f\x93\xa7 envelope",
-            "To" => "To Alias 1 \xf0\x9f\x93\xa7 envelope <to+1@example.com>," .
+            'Return-Path' => '<return-path@example.com>',
+            'From' => "From Alias \xf0\x9f\x93\xa7 envelope <from@example.com>",
+            'Reply-To' => 'reply-to@example.com',
+            'To' => "To Alias 1 \xf0\x9f\x93\xa7 envelope <to+1@example.com>," .
                 " To Alias 2 \xf0\x9f\x93\xa7 envelope <to+2@example.com>",
-            "Cc" => 'cc@example.com',
-            "Reply-To" => 'reply-to@example.com'
+            'Cc' => 'cc@example.com',
+            'Subject' => "subject line with \xf0\x9f\x93\xa7 envelope",
         ];
 
         return $expected;

--- a/tests/Mime/AbstractMimeTest.php
+++ b/tests/Mime/AbstractMimeTest.php
@@ -136,7 +136,7 @@ class AbstractMimeTest extends TestCase
         $contentHtml = '<b>HTML Content</b>';
         $htmlPart->setContent($contentHtml);
         $htmlPart->setCharset('UTF-8');
-        $expected[] = "Content-Type: text/html; charset=\"UTF-8\"\r\n"
+        $expected[] = "Content-Type: text/html; charset=UTF-8\r\n"
             . "Content-Transfer-Encoding: quoted-printable\r\n"
             . "\r\n{$contentHtml}";
 
@@ -144,7 +144,7 @@ class AbstractMimeTest extends TestCase
         $contentText = 'Text Content';
         $textPart->setContent($contentText);
         $textPart->setCharset('UTF-8');
-        $expected[] = "Content-Type: text/plain; charset=\"UTF-8\"\r\n"
+        $expected[] = "Content-Type: text/plain; charset=UTF-8\r\n"
             . "Content-Transfer-Encoding: quoted-printable\r\n"
             . "\r\n{$contentText}";
 

--- a/tests/__files/attachments-expected-headers.txt
+++ b/tests/__files/attachments-expected-headers.txt
@@ -24,7 +24,6 @@ MIME-Version: 1.0
 X-Virus-Scanned: amavisd-new at example.com
 X-Spam-Flag: NO
 X-Spam-Score: -1.507
-X-Spam-Level: 
 X-Spam-Status: No, score=-1.507 tagged_above=-10 required=6.6
  tests=[BAYES_00=-1.9, DKIM_SIGNED=0.1, DKIM_VALID=-0.1, DKIM_VALID_AU=-0.1,
  FREEMAIL_FROM=0.001, HTML_IMAGE_ONLY_04=1.172, HTML_MESSAGE=0.001,

--- a/tests/__files/attachments-expected-headers.txt
+++ b/tests/__files/attachments-expected-headers.txt
@@ -1,7 +1,7 @@
 Return-Path: <sender@example.com>
 From: From Name <from@example.com>
-Subject: Attachments
 To: recipient@example.com
+Subject: Attachments
 MIME-Version: 1.0
 Received: from mail.example.com (LHLO mail.example.com) (10.1.9.1) by
  mail.example.com with LMTP; Thu, 16 Aug 2012 15:45:43 +0100 (BST)

--- a/tests/__files/attachments-expected-headers.txt
+++ b/tests/__files/attachments-expected-headers.txt
@@ -1,6 +1,7 @@
 Return-Path: <sender@example.com>
 From: From Name <from@example.com>
 To: recipient@example.com
+Message-Id: <CAJ_TRnL=YMObf2FT9bU7NO0ziPYxpnxfxrtOz4r2-aBxkHSOrA@mail.gmail.com>
 Subject: Attachments
 MIME-Version: 1.0
 Received: from mail.example.com (LHLO mail.example.com) (10.1.9.1) by
@@ -42,4 +43,3 @@ Dkim-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;        d=gmail.com;
  6SGg==
 X-Goomoji-Body: true
 Date: Thu, 16 Aug 2012 15:45:32 +0100
-Message-Id: <CAJ_TRnL=YMObf2FT9bU7NO0ziPYxpnxfxrtOz4r2-aBxkHSOrA@mail.gmail.com>

--- a/tests/__files/attachments-expected-headers.txt
+++ b/tests/__files/attachments-expected-headers.txt
@@ -1,25 +1,26 @@
 Return-Path: <sender@example.com>
+Received: from mail.example.com (LHLO mail.example.com) (10.1.9.1) by
+ mail.example.com with LMTP; Thu, 16 Aug 2012 15:45:43 +0100
+Received: from localhost (localhost [127.0.0.1]) by mail.example.com (Postfix)
+ with ESMTP id ED35D161D86 for <recipient@example.com>; Thu, 16 Aug 2012
+ 15:45:43 +0100
+Received: from mail.example.com ([127.0.0.1]) by localhost (mail.example.com
+ [127.0.0.1]) (amavisd-new, port 10024) with ESMTP id x9xbo4ZNbRu7 for
+ <recipient@example.com>; Thu, 16 Aug 2012 15:45:42 +0100
+Received: from mail-yx0-f181.google.com (mail-yx0-f181.google.com
+ [209.85.213.181]) by mail.example.com (Postfix) with ESMTPS id 92F4A161D85
+ for <recipient@example.com>; Thu, 16 Aug 2012 15:45:41 +0100
+Received: by yenq13 with SMTP id q13so3462367yen.40        for
+ <recipient@example.com>; Thu, 16 Aug 2012 07:45:40 -0700
+Received: by 10.50.76.202 with SMTP id m10mr1877022igw.52.1345128339903; Thu,
+ 16 Aug 2012 07:45:39 -0700
+Received: by 10.64.82.163 with HTTP; Thu, 16 Aug 2012 07:45:32 -0700
+Date: Thu, 16 Aug 2012 15:45:32 +0100
 From: From Name <from@example.com>
 To: recipient@example.com
 Message-Id: <CAJ_TRnL=YMObf2FT9bU7NO0ziPYxpnxfxrtOz4r2-aBxkHSOrA@mail.gmail.com>
 Subject: Attachments
 MIME-Version: 1.0
-Received: from mail.example.com (LHLO mail.example.com) (10.1.9.1) by
- mail.example.com with LMTP; Thu, 16 Aug 2012 15:45:43 +0100 (BST)
-Received: from localhost (localhost [127.0.0.1]) by mail.example.com (Postfix)
- with ESMTP id ED35D161D86 for <recipient@example.com>; Thu, 16 Aug 2012
- 15:45:43 +0100 (BST)
-Received: from mail.example.com ([127.0.0.1]) by localhost (mail.example.com
- [127.0.0.1]) (amavisd-new, port 10024) with ESMTP id x9xbo4ZNbRu7 for
- <recipient@example.com>; Thu, 16 Aug 2012 15:45:42 +0100 (BST)
-Received: from mail-yx0-f181.google.com (mail-yx0-f181.google.com
- [209.85.213.181]) by mail.example.com (Postfix) with ESMTPS id 92F4A161D85
- for <recipient@example.com>; Thu, 16 Aug 2012 15:45:41 +0100 (BST)
-Received: by yenq13 with SMTP id q13so3462367yen.40        for
- <recipient@example.com>; Thu, 16 Aug 2012 07:45:40 -0700 (PDT)
-Received: by 10.50.76.202 with SMTP id m10mr1877022igw.52.1345128339903; Thu,
- 16 Aug 2012 07:45:39 -0700 (PDT)
-Received: by 10.64.82.163 with HTTP; Thu, 16 Aug 2012 07:45:32 -0700 (PDT)
 X-Virus-Scanned: amavisd-new at example.com
 X-Spam-Flag: NO
 X-Spam-Score: -1.507
@@ -42,4 +43,3 @@ Dkim-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;        d=gmail.com;
  bU+IexdOG/O4XcauU1Qk8gGm0xA3szGZXGaaji8eBgknY8E6bxNItIiDaJ9vHGLvyMZj        
  6SGg==
 X-Goomoji-Body: true
-Date: Thu, 16 Aug 2012 15:45:32 +0100

--- a/tests/__files/bounce_head-expected-headers.txt
+++ b/tests/__files/bounce_head-expected-headers.txt
@@ -1,11 +1,11 @@
+Received: from mta65117.example.com (mta65117.example.com [109.68.65.117])    
+    by mail.example.com (Postfix) with ESMTP id 413291A0374        for
+ <bounce-1149-42342-20831917-live@mail.example.com>; Mon, 20 Aug 2012 05:17:28
+ +0100
+Date: Mon, 20 Aug 2012 05:15:26 +0100
 From: postmaster@mta65117.example.com
 To: bounce-1149-42342-20831917-live@mail.example.com
 Subject: Delivery report
 MIME-Version: 1.0
 X-Original-To: bounce-1149-42342-20831917-live@mail.example.com
 Delivered-To: bounce@mail.example.com
-Received: from mta65117.example.com (mta65117.example.com [109.68.65.117])    
-    by mail.example.com (Postfix) with ESMTP id 413291A0374        for
- <bounce-1149-42342-20831917-live@mail.example.com>; Mon, 20 Aug 2012 05:17:28
- +0100 (BST)
-Date: Mon, 20 Aug 2012 05:15:26 +0100

--- a/tests/__files/bounce_head-expected-headers.txt
+++ b/tests/__files/bounce_head-expected-headers.txt
@@ -1,6 +1,6 @@
 From: postmaster@mta65117.example.com
-Subject: Delivery report
 To: bounce-1149-42342-20831917-live@mail.example.com
+Subject: Delivery report
 MIME-Version: 1.0
 X-Original-To: bounce-1149-42342-20831917-live@mail.example.com
 Delivered-To: bounce@mail.example.com

--- a/tests/__files/bounce_msg-expected-headers.txt
+++ b/tests/__files/bounce_msg-expected-headers.txt
@@ -1,17 +1,17 @@
-From: postmaster@example.com
-To: bounce-1149-42363-11284257-live@mail.example.com
-Subject: Undeliverable: Julie, your home renewal is due
-MIME-Version: 1.0
-X-Original-To: bounce-1149-42363-11284257-live@mail.example.com
-Delivered-To: bounce@mail.example.com
 Received: from smtp1.example.com (smtp2.example.com [205.149.24.12]) by
  mail.example.com (Postfix) with ESMTP id A2E901A0374 for
  <bounce-1149-42363-11284257-live@mail.example.com>; Mon, 20 Aug 2012 12:02:25
- +0100 (BST)
+ +0100
 Received: from uspexhub02.example.com (10.50.51.21) by smtp2.example.com
  (192.168.50.12) with Microsoft SMTP Server (TLS) id 8.3.245.1; Mon, 20 Aug
  2012 07:02:33 -0400
 Date: Mon, 20 Aug 2012 07:02:24 -0400
-Content-Language: en-US
+From: postmaster@example.com
+To: bounce-1149-42363-11284257-live@mail.example.com
 In-Reply-To: <0.0.F4.BD6.1CD7EC2FB28D3A2.0@mta65117.example.com>
 References: <0.0.F4.BD6.1CD7EC2FB28D3A2.0@mta65117.example.com>
+Subject: Undeliverable: Julie, your home renewal is due
+MIME-Version: 1.0
+X-Original-To: bounce-1149-42363-11284257-live@mail.example.com
+Delivered-To: bounce@mail.example.com
+Content-Language: en-US

--- a/tests/__files/bounce_msg-expected-headers.txt
+++ b/tests/__files/bounce_msg-expected-headers.txt
@@ -13,6 +13,5 @@ Received: from uspexhub02.example.com (10.50.51.21) by smtp2.example.com
  2012 07:02:33 -0400
 Date: Mon, 20 Aug 2012 07:02:24 -0400
 Content-Language: en-US
-Message-Id: <2b2c1a86-066f-47e6-a318-6a206ce97d78>
 In-Reply-To: <0.0.F4.BD6.1CD7EC2FB28D3A2.0@mta65117.example.com>
 References: <0.0.F4.BD6.1CD7EC2FB28D3A2.0@mta65117.example.com>

--- a/tests/__files/bounce_msg-expected-headers.txt
+++ b/tests/__files/bounce_msg-expected-headers.txt
@@ -1,6 +1,6 @@
 From: postmaster@example.com
-Subject: Undeliverable: Julie, your home renewal is due
 To: bounce-1149-42363-11284257-live@mail.example.com
+Subject: Undeliverable: Julie, your home renewal is due
 MIME-Version: 1.0
 X-Original-To: bounce-1149-42363-11284257-live@mail.example.com
 Delivered-To: bounce@mail.example.com

--- a/tests/__files/content_attachment-expected-headers.txt
+++ b/tests/__files/content_attachment-expected-headers.txt
@@ -1,9 +1,9 @@
 From: Owner <owner@example.com>
 Reply-To: Owner <owner@example.com>
 To: Recipient Name <recipient@example.com>
+Message-Id: <20121219102623.0D45A1620AA@mail.example.com>
 Subject: Welcome NAME HERE
 Received: from localhost (track.example.com. [10.1.6.5]) by trx.example.com
  with ESMTP (stage ESMTP Postfix); Wed, 19 Dec 2012 10:26:22 +0000
 Content-Disposition: inline
-Message-Id: <20121219102623.0D45A1620AA@mail.example.com>
 Date: Wed, 19 Dec 2012 10:26:23 +0000 (GMT)

--- a/tests/__files/content_attachment-expected-headers.txt
+++ b/tests/__files/content_attachment-expected-headers.txt
@@ -1,7 +1,7 @@
 From: Owner <owner@example.com>
-Subject: Welcome NAME HERE
-To: Recipient Name <recipient@example.com>
 Reply-To: Owner <owner@example.com>
+To: Recipient Name <recipient@example.com>
+Subject: Welcome NAME HERE
 Received: from localhost (track.example.com. [10.1.6.5]) by trx.example.com
  with ESMTP (stage ESMTP Postfix); Wed, 19 Dec 2012 10:26:22 +0000
 Content-Disposition: inline

--- a/tests/__files/content_attachment-expected-headers.txt
+++ b/tests/__files/content_attachment-expected-headers.txt
@@ -1,9 +1,9 @@
+Received: from localhost (track.example.com. [10.1.6.5]) by trx.example.com
+ with ESMTP (stage ESMTP Postfix); Wed, 19 Dec 2012 10:26:22 +0000
+Date: Wed, 19 Dec 2012 10:26:23 +0000
 From: Owner <owner@example.com>
 Reply-To: Owner <owner@example.com>
 To: Recipient Name <recipient@example.com>
 Message-Id: <20121219102623.0D45A1620AA@mail.example.com>
 Subject: Welcome NAME HERE
-Received: from localhost (track.example.com. [10.1.6.5]) by trx.example.com
- with ESMTP (stage ESMTP Postfix); Wed, 19 Dec 2012 10:26:22 +0000
 Content-Disposition: inline
-Date: Wed, 19 Dec 2012 10:26:23 +0000 (GMT)

--- a/tests/__files/html-expected-headers.txt
+++ b/tests/__files/html-expected-headers.txt
@@ -1,9 +1,9 @@
 Return-Path: <bounce-100-250-1831-live@mail.example.com>
 From: Events <eventmarketing@example.com>
+Reply-To: Events <eventmarketing@example.com>
+To: recipient@example.com
 Subject: London Olympics: Business Continuity Plan - =?UTF-8?Q?=C2=A3100?=
  discount today only!
-To: recipient@example.com
-Reply-To: Events <eventmarketing@example.com>
 Received: from gbnthda3150srv.example.com ([10.67.121.52]) by
  GBLONVMSX001.nsicorp.int with Microsoft SMTPSVC(6.0.3790.4675);  Thu, 29 Sep
  2011 08:48:51 +0100

--- a/tests/__files/html-expected-headers.txt
+++ b/tests/__files/html-expected-headers.txt
@@ -2,6 +2,7 @@ Return-Path: <bounce-100-250-1831-live@mail.example.com>
 From: Events <eventmarketing@example.com>
 Reply-To: Events <eventmarketing@example.com>
 To: recipient@example.com
+Message-Id: <0.0.24D.2F1.1CC79CE6346CBD8.0@mta6551.example.com>
 Subject: London Olympics: Business Continuity Plan - =?UTF-8?Q?=C2=A3100?=
  discount today only!
 Received: from gbnthda3150srv.example.com ([10.67.121.52]) by
@@ -17,7 +18,6 @@ Received: by mta6551.example.com (PowerMTA(TM) v3.5r14) id hfh4js0sv5km for
  <recipient@example.com>; Fri, 23 Sep 2011 09:54:22 +0100 (envelope-from
  <bounce-100-250-1831-live@mail.example.com>)
 X-Mailer: MXM-v5-MailEngine
-Message-Id: <0.0.24D.2F1.1CC79CE6346CBD8.0@mta6551.example.com>
 Date: Fri, 23 Sep 2011 09:54:22 +0100
 X-Tm-As-Product-Ver: SMEX-8.0.0.1181-6.500.1024-18336.002
 X-Tm-As-Result: No--4.601200-8.000000-31

--- a/tests/__files/html-expected-headers.txt
+++ b/tests/__files/html-expected-headers.txt
@@ -1,24 +1,22 @@
 Return-Path: <bounce-100-250-1831-live@mail.example.com>
+Received: from gbnthda3150srv.example.com ([10.67.121.52]) by
+ GBLONVMSX001.nsicorp.int with Microsoft SMTPSVC(6.0.3790.4675); Thu, 29 Sep
+ 2011 08:48:51 +0100
+Received: from localhost (unknown [127.0.0.1]) by IMSVA80 (Postfix) with SMTP
+ id E307622003E for <recipient@example.com>; Thu, 29 Sep 2011 08:48:58 +0100
+Received: from mta6551.example.com (unknown [109.68.65.51]) by
+ gbnthda3150srv.example.com (Postfix) with ESMTP id 6F72A220057 for
+ <recipient@example.com>; Fri, 23 Sep 2011 09:54:25 +0100
+Received: by mta6551.example.com (PowerMTA(TM) v3.5r14) id hfh4js0sv5km for
+ <recipient@example.com>; Fri, 23 Sep 2011 09:54:22 +0100
+Date: Fri, 23 Sep 2011 09:54:22 +0100
 From: Events <eventmarketing@example.com>
 Reply-To: Events <eventmarketing@example.com>
 To: recipient@example.com
 Message-Id: <0.0.24D.2F1.1CC79CE6346CBD8.0@mta6551.example.com>
 Subject: London Olympics: Business Continuity Plan - =?UTF-8?Q?=C2=A3100?=
  discount today only!
-Received: from gbnthda3150srv.example.com ([10.67.121.52]) by
- GBLONVMSX001.nsicorp.int with Microsoft SMTPSVC(6.0.3790.4675);  Thu, 29 Sep
- 2011 08:48:51 +0100
-Received: from localhost (unknown [127.0.0.1]) by IMSVA80 (Postfix) with SMTP
- id E307622003E for <recipient@example.com>; Thu, 29 Sep 2011 08:48:58 +0100
- (BST)
-Received: from mta6551.example.com (unknown [109.68.65.51]) by
- gbnthda3150srv.example.com (Postfix) with ESMTP id 6F72A220057 for
- <recipient@example.com>; Fri, 23 Sep 2011 09:54:25 +0100 (BST)
-Received: by mta6551.example.com (PowerMTA(TM) v3.5r14) id hfh4js0sv5km for
- <recipient@example.com>; Fri, 23 Sep 2011 09:54:22 +0100 (envelope-from
- <bounce-100-250-1831-live@mail.example.com>)
 X-Mailer: MXM-v5-MailEngine
-Date: Fri, 23 Sep 2011 09:54:22 +0100
 X-Tm-As-Product-Ver: SMEX-8.0.0.1181-6.500.1024-18336.002
 X-Tm-As-Result: No--4.601200-8.000000-31
 X-Imss-Scan-Details: No--12.138-5.0-31-10


### PR DESCRIPTION
This is the big one! Definitely best to review by commit. The final aim is to have all headers built as Symfony/Mime objects.

Public interface is largely unaffected, apart from the removal of a method which isn't used in our implementations. This means the tests are largely unchanged, except where the Symfony header encoding has improved the output (eg. removing unnecessary double-quotes, adding correct line-breaks).