### PR TITLE
Add date regex to Factory test for standard format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Exception thrown from Factory when Original Date header value does not match
+  the expected standard and cannot be parsed by PHP.
+  Now try to find standards-compliant date within the string, and fall back to
+  trying the string directly but ignoring any values which still fail.
 
 ## [4.0.1] - 2019-12-06
 ### Fixed


### PR DESCRIPTION
If the regex fails to match, try PHP and ignore strings that still don't pass.

This is causing an issue for some bounce emails, which have an invalid date containing a double-timezone identifier. It causes PHP to throw an exception when instantiating the DateTime object:

> Failed to parse time string (Mon, 9 Dec 2019 18:36:20 +0800 (GMT+08:00)) at position 35 (+): Double timezone specification