### PR TITLE
Add support for a space used for a single-digit date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Add support for a space used for a single-digit date (i.e. instead of leading 
+  zero) in the origination date and received headers.
 
 ## [4.0.2] - 2019-12-12
 ### Fixed

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -16,7 +16,7 @@ class Factory
      *
      * @var string
      */
-    private const DATE_REGEX = '/((?:\w{3},\s)?\d{1,2}\s\w{3}\s\d{4}\s\d{2}:\d{2}(?::\d{2})?\s(?:\+|-)\d{4})/';
+    private const DATE_REGEX = '/((?:\w{3},\s{1,2})?\d{1,2}\s\w{3}\s\d{4}\s\d{2}:\d{2}(?::\d{2})?\s(?:\+|-)\d{4})/';
 
     /**
      * Capture the date part separately from the rest of the header, matching RFC5322 §3.6.7
@@ -30,7 +30,7 @@ class Factory
      * (envelope-from <bounce-100-250-1831-live@mail.example.com>)"
      * @var string
      */
-    private const RECEIVED_REGEX = '/^(.*);\s*((?:\w{3},\s)?\d{1,2}\s\w{3}\s\d{4}\s\d{2}:\d{2}(?::\d{2})?\s(?:\+|-)\d{4})/';
+    private const RECEIVED_REGEX = '/^(.*);\s*((?:\w{3},\s{1,2})?\d{1,2}\s\w{3}\s\d{4}\s\d{2}:\d{2}(?::\d{2})?\s(?:\+|-)\d{4})/';
 
     /**
      * @var bool


### PR DESCRIPTION
Origination date and received headers may contain invalid space, but it's easy to handle.

This is showing up in bounce emails, which seems to often have invalid formats.