### PR TITLE
Header decode spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Additional whitespace being output in PHP v8.3+ for header values which use
+  encoded-words split across multiple lines.
 
 ## [4.0.4] - 2023-10-16
 ### Changed

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -383,6 +383,18 @@ class Factory
                 }, $header);
             }
 
+            /**
+             * Since PHP v8.3 the reimplementation of mbstring is aligned with RFC 2047,
+             * where consecutive encoded-words MUST be separated by CRLF+SPACE.
+             * However, Mailparse returns the header lines concatenated without the CRLF, leaving only the space.
+             * The space is then output as genuine whitespace whereas it should be ignored.
+             * Reinserting the CRLF avoids this, but means that any deliberate spaces between encoded-words which
+             * were not originally CRLF+SPACE will lose their space; this is unlikely in real-world scenarios.
+             */
+            $header = preg_replace_callback('/(=\?[^\?]+\?[^\?]\?[^\?]+\?=) (=\?[^\?]+\?[^\?]\?[^\?]+\?=)/i', function ($matches) {
+                return $matches[1] . "\r\n " . $matches[2];
+            }, $header);
+
             $header = mb_decode_mimeheader($header);
         }
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -374,9 +374,14 @@ class Factory
             }
 
             // Workaround for https://bugs.php.net/bug.php?id=68821
-            $header = preg_replace_callback('/(=\?[^\?]+\?Q\?)([^\?]+)(\?=)/i', function ($matches) {
-                return $matches[1] . str_replace('_', '=20', $matches[2]) . $matches[3];
-            }, $header);
+            // Fixed in PHP v8.3
+            // https://www.php.net/manual/en/migration83.other-changes.php#migration83.other-changes.functions.mbstring
+            // Commit: https://github.com/php/php-src/commit/8995f602584a5267999f51cbc73f8c03eee36074
+            if (PHP_VERSION_ID < 80300) {
+                $header = preg_replace_callback('/(=\?[^\?]+\?Q\?)([^\?]+)(\?=)/i', function ($matches) {
+                    return $matches[1] . str_replace('_', '=20', $matches[2]) . $matches[3];
+                }, $header);
+            }
 
             $header = mb_decode_mimeheader($header);
         }


### PR DESCRIPTION
- Put a version check against a bug workaround no longer needed for PHP v8.3
- Fix extra space showing in headers using encoded-words split across multiple lines in PHP v8.3